### PR TITLE
Refactor Asset Handling

### DIFF
--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -35,7 +35,7 @@ class AssetsTransformer extends AbstractTransformer
                 }
 
                 $assetContainer->disk()->put($path, $request->body());
-                $asset = $assetContainer->makeAsset($path);
+                $asset = tap($assetContainer->makeAsset($path))->save();
             }
 
             return $asset?->path();

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -4,6 +4,7 @@ namespace Statamic\Importer\Transformers;
 
 use Illuminate\Support\Facades\Http;
 use Statamic\Facades\AssetContainer;
+use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Bard\Augmentor as BardAugmentor;
 use Statamic\Importer\WordPress\Gutenberg;
 use Statamic\Support\Str;
@@ -28,27 +29,18 @@ class BardTransformer extends AbstractTransformer
         return collect($value)
             ->map(function (array $node): ?array {
                 if ($this->field->get('container') && $node['type'] === 'image') {
-                    $baseUrl = $this->config('assets_base_url');
-                    $downloadWhenMissing = $this->config('assets_download_when_missing', false);
                     $assetContainer = AssetContainer::find($this->field->get('container'));
 
-                    $path = Str::of($node['attrs']['src'])
-                        ->after(Str::removeRight($baseUrl, '/'))
-                        ->trim('/')
-                        ->__toString();
+                    $transformer = new AssetsTransformer(
+                        field: new Field('image', ['container' => $assetContainer->handle(), 'max_files' => 1]),
+                        config: [
+                            'related_field' => 'url',
+                            'base_url' => $this->config['assets_base_url'] ?? null,
+                            'download_when_missing' => $this->config['assets_download_when_missing'] ?? false,
+                        ]
+                    );
 
-                    $asset = $assetContainer->asset($path);
-
-                    if (! $asset && $downloadWhenMissing) {
-                        $request = Http::get(Str::removeRight($baseUrl, '/').Str::ensureLeft($path, '/'));
-
-                        if (! $request->ok()) {
-                            return null;
-                        }
-
-                        $assetContainer->disk()->put($path, $request->body());
-                        $asset = $assetContainer->makeAsset($path);
-                    }
+                    $asset = $assetContainer->asset(path: $transformer->transform($node['attrs']['src']));
 
                     if (! $asset) {
                         return null;

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -28,7 +28,7 @@ class BardTransformer extends AbstractTransformer
 
         return collect($value)
             ->map(function (array $node): ?array {
-                if ($this->field->get('container') && $node['type'] === 'image') {
+                if ($node['type'] === 'image' && $this->field->get('container') && isset($this->config['assets_base_url'])) {
                     $assetContainer = AssetContainer::find($this->field->get('container'));
 
                     $transformer = new AssetsTransformer(

--- a/src/WordPress/Gutenberg.php
+++ b/src/WordPress/Gutenberg.php
@@ -61,7 +61,7 @@ class Gutenberg
                     ];
                 }
 
-                if ($field->get('container') && $block['blockName'] === 'core/image') {
+                if ($block['blockName'] === 'core/image' && $field->get('container') && isset($config['assets_base_url'])) {
                     $assetContainer = AssetContainer::find($field->get('container'));
 
                     $crawler = new Crawler($block['innerHTML']);
@@ -96,7 +96,7 @@ class Gutenberg
                     ];
                 }
 
-                if ($block['blockName'] === 'core/gallery') {
+                if ($block['blockName'] === 'core/gallery' && isset($config['assets_base_url'])) {
                     $assetContainer = $field->get('container')
                         ? AssetContainer::find($field->get('container'))
                         : AssetContainer::all()->first();

--- a/tests/Transformers/BardTransformerTest.php
+++ b/tests/Transformers/BardTransformerTest.php
@@ -104,4 +104,36 @@ HTML);
             ],
         ], $output);
     }
+
+    #[Test]
+    public function it_doesnt_handles_images_without_base_url()
+    {
+        AssetContainer::make('assets')->disk('public')->save();
+        Storage::disk('public')->put('2024/10/image.png', 'original');
+
+        $transformer = new BardTransformer($this->blueprint, $this->field, []);
+
+        $output = $transformer->transform(<<<'HTML'
+<p>Nam voluptatem rem molestiae cumque doloremque. <strong>Saepe animi deserunt</strong> Maxime iam et inventore. ipsam in dignissimos qui occaecati.</p>
+<img src="https://example.com/wp-content/uploads/2024/10/image.png" />
+HTML);
+
+        $this->assertEquals([
+            [
+                'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
+                'content' => [
+                    ['type' => 'text', 'text' => 'Nam voluptatem rem molestiae cumque doloremque. '],
+                    ['type' => 'text', 'text' => 'Saepe animi deserunt', 'marks' => [['type' => 'bold']]],
+                    ['type' => 'text', 'text' => ' Maxime iam et inventore. ipsam in dignissimos qui occaecati.'],
+                ],
+            ],
+            [
+                'type' => 'image',
+                'attrs' => [
+                    'src' => 'https://example.com/wp-content/uploads/2024/10/image.png',
+                ],
+            ],
+        ], $output);
+    }
 }


### PR DESCRIPTION
This pull request aims to simplify how assets are handled within Bard fields.

Previously, the logic for finding & downloading assets was duplicated across a few different classes. This PR simplifies that by relying on just the `AssetsTransformer`, since it seems the most logical place to keep it.

This PR also fixes an issue when importing Bard content with images, but *without* a "Base URL" set where you'd get an error complaining about the parameters being passed to a method.