### PR TITLE
WordPress: Filter out `attachment` posts

### DIFF
--- a/.github/workflows/pint-fix.yml
+++ b/.github/workflows/pint-fix.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fix-php-code-styling:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'statamic-rad-pack'
+    if: github.repository_owner == 'statamic'
 
     steps:
       - name: Checkout code

--- a/src/Http/Controllers/MappingsController.php
+++ b/src/Http/Controllers/MappingsController.php
@@ -49,7 +49,7 @@ class MappingsController extends CpController
                             'hide_display' => true,
                             'options' => collect($row)->map(fn ($value, $key) => [
                                 'key' => $key,
-                                'value' => "<{$key}>: " . Str::truncate($value, 200),
+                                'value' => "<{$key}>: ".Str::truncate($value, 200),
                             ])->values(),
                             'clearable' => true,
                         ],

--- a/src/Sources/Xml.php
+++ b/src/Sources/Xml.php
@@ -30,6 +30,11 @@ class Xml extends AbstractSource
                     }
                 }
 
+                // WordPress: Filter out any `attachment` post types.
+                if (isset($array['wp:post_type']) && $array['wp:post_type'] === 'attachment') {
+                    continue;
+                }
+
                 yield $array;
             }
         });

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Importer\Transformers;
 
-use Illuminate\Support\Facades\Http;
 use Statamic\Facades\AssetContainer;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Bard\Augmentor as BardAugmentor;

--- a/src/WordPress/Gutenberg.php
+++ b/src/WordPress/Gutenberg.php
@@ -117,7 +117,7 @@ class Gutenberg
                                 'type' => 'gallery',
                                 'images' => collect($block['innerBlocks'])
                                     ->filter(fn ($block) => $block['blockName'] === 'core/image')
-                                    ->map(function (array $block) use ($config, $field, $assetContainer): string {
+                                    ->map(function (array $block) use ($config, $field): string {
                                         $crawler = new Crawler($block['innerHTML']);
                                         $url = $crawler->filter('img')->first()->attr('src');
 


### PR DESCRIPTION
When you export posts in WordPress, the export seems to include `attachment` posts as well as _actual_ posts. And because they're combined in the same file, Statamic will try to import them as well, which isn't ideal.

This pull request aims to address this by simply filtering out items where `wp:post_type` is `attachment`. 

At some point, we may build in some more advanced filtering of items, but this will do for now, given a high percentage of imports will likely be coming from WordPress.

Closes #5.