### PR TITLE
Import Strategy

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -25,7 +25,7 @@ Before importing, you will need to do some preparation:
 
 ### Importing
 1. Navigate to the Importer utility in the Control Panel.
-2. Give your import a name, and upload the file you wish to import. You'll also be asked which type of content you're importing (entries, taxonomy terms, or users).
+2. Give your import a name, and upload the file you wish to import. You'll also be asked which type of content you're importing (entries, taxonomy terms, or users) and if you want to create new items or update existing items.
 3. You can then map fields from your blueprint to fields/columns in your file.
     * Depending on the fieldtype, some fields may have additional options, like "Related Key" or "Create when missing". You can read more about these below.
     * Mapping is disabled for some fieldtypes, like the [Replicator fieldtype](https://statamic.dev/fieldtypes/replicator#content). If you wish to import these fields, you will need to build a [custom transformer](#transformers).

--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -66,6 +66,10 @@ class ImportController extends CpController
             ->config([
                 'type' => $type,
                 'path' => Storage::disk('local')->path($path),
+                'strategy' => [
+                    'create' => in_array('create', $request->strategy),
+                    'update' => in_array('update', $request->strategy),
+                ],
                 'destination' => [
                     'type' => $request->destination_type,
                     'collection' => Arr::first($request->destination_collection),
@@ -176,6 +180,16 @@ class ImportController extends CpController
                 'mode' => 'select',
                 'if' => ['destination_type' => 'terms'],
                 'validate' => 'required',
+            ],
+            'strategy' => [
+                'type' => 'checkboxes',
+                'display' => __('Import Strategy'),
+                'instructions' => __('Choose what should happen when importing.'),
+                'options' => [
+                    ['key' => 'create', 'value' => __('Create new items')],
+                    ['key' => 'update', 'value' => __('Update existing items')],
+                ],
+                'default' => ['create', 'update'],
             ],
         ]);
     }

--- a/src/Http/Requests/CreateImportRequest.php
+++ b/src/Http/Requests/CreateImportRequest.php
@@ -52,6 +52,8 @@ class CreateImportRequest extends FormRequest
                     $fail('Taxonomy could not be found.')->translate();
                 }
             }],
+            'strategy' => ['required', 'array', 'min:1'],
+            'strategy.*' => ['required', 'in:create,update'],
         ];
     }
 }

--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -76,7 +76,15 @@ class ImportItemJob implements ShouldQueue
             ->first();
 
         if (! $entry) {
+            if (! $this->import->get('strategy.create', true)) {
+                return;
+            }
+
             $entry = Entry::make()->collection($this->import->get('destination.collection'));
+        }
+
+        if ($entry->id() && ! $this->import->get('strategy.update', true)) {
+            return;
         }
 
         if (isset($data['slug'])) {
@@ -103,7 +111,15 @@ class ImportItemJob implements ShouldQueue
             ->first();
 
         if (! $term) {
+            if (! $this->import->get('strategy.create', true)) {
+                return;
+            }
+
             $term = Term::make()->taxonomy($this->import->get('destination.taxonomy'));
+        }
+
+        if (Term::find($term->id()) && ! $this->import->get('strategy.update', true)) {
+            return;
         }
 
         if (isset($data['slug'])) {
@@ -126,7 +142,15 @@ class ImportItemJob implements ShouldQueue
             ->first();
 
         if (! $user) {
+            if (! $this->import->get('strategy.create', true)) {
+                return;
+            }
+
             $user = User::make();
+        }
+
+        if ($user->id() && ! $this->import->get('strategy.update', true)) {
+            return;
         }
 
         if (isset($data['email'])) {

--- a/tests/Imports/StoreImportTest.php
+++ b/tests/Imports/StoreImportTest.php
@@ -108,7 +108,7 @@ class StoreImportTest extends TestCase
         $this->assertEquals('Users', $import->name());
         $this->assertEquals('csv', $import->get('type'));
         $this->assertEquals(storage_path('app/statamic/imports/users.csv'), $import->get('path'));
-        $this->assertEquals(['create' => true, 'update' => true, 'delete' => false], $import->get('strategy'));
+        $this->assertEquals(['create' => true, 'update' => true], $import->get('strategy'));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request adds a new "Import Strategy" option when configuring imports, allowing you to specify if new items should be created and if existing items should be updated.

![CleanShot 2024-10-29 at 13 03 48](https://github.com/user-attachments/assets/e8104ec4-f3a6-41a1-bb2a-9d34ce50c876)

This option can be particularly useful if you're importing the same spreadsheet multiple times, but only want new rows on that spreadsheet to create entries.

Closes #9.