### PR TITLE
Import entry parents

### DIFF
--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -103,6 +104,25 @@ class ImportItemJob implements ShouldQueue
 
         if (isset($data['date'])) {
             $entry->date(Arr::pull($data, 'date'));
+        }
+
+        if ($structure = $collection->structure()) {
+            $parent = Arr::pull($data, 'parent');
+
+            $entry->afterSave(function ($entry) use ($structure, $site, $parent, $data) {
+                $tree = $structure->in($site->handle());
+
+                if (! $tree->find($entry->id())) {
+                    $tree->append($entry)->save();
+                }
+
+                if ($parent) {
+                    $parents = Cache::get("importer.{$this->import->id()}.parents", []);
+                    $parents[] = ['id' => $entry->id(), 'parent' => $parent];
+
+                    Cache::forever("importer.{$this->import->id()}.parents", $parents);
+                }
+            });
         }
 
         $entry->merge($data);

--- a/src/Jobs/UpdateCollectionTreeJob.php
+++ b/src/Jobs/UpdateCollectionTreeJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Statamic\Importer\Jobs;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Cache;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+use Statamic\Importer\Imports\Import;
+use Statamic\Importer\Support\SortByParent;
+
+class UpdateCollectionTreeJob implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct(public Import $import) {}
+
+    public function handle(): void
+    {
+        $collection = Collection::find($this->import->get('destination.collection'));
+
+        $tree = $collection->structure()?->in($this->import->get('destination.site') ?? Site::default()->handle());
+
+        if (! $tree) {
+            return;
+        }
+
+        $parents = (new SortByParent())->sort(Cache::get("importer.{$this->import->id}.parents"));
+
+        collect($parents)->each(function (array $item) use ($tree) {
+            $entry = Entry::find($item['id']);
+
+            $tree->move($entry->id(), $item['parent']);
+        });
+
+        $tree->save();
+
+        Cache::forget("importer.{$this->import->id}.parents");
+    }
+}

--- a/src/Support/SortByParent.php
+++ b/src/Support/SortByParent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Statamic\Importer\Support;
+
+class SortByParent
+{
+    public function sort(array $items): array
+    {
+        // Create a map of item IDs to their items for quick access
+        $itemsById = collect($items)->keyBy('id')->all();
+        $sorted = [];
+        $addedIds = [];
+
+        // Start adding items with their children
+        foreach ($itemsById as $item) {
+            // Check if the item has already been added
+            if (! in_array($item['id'], $addedIds)) {
+                $this->addItemWithChildren($itemsById, $sorted, $addedIds, $item['parent']);
+            }
+        }
+
+        return $sorted;
+    }
+
+    private function addItemWithChildren(array $itemsById, array &$sorted, array &$addedIds, int|string $parentId): void
+    {
+        // First, add the parent item if it exists and hasn't been added yet
+        if ($parentId && isset($itemsById[$parentId]) && ! in_array($parentId, $addedIds)) {
+            $parentItem = $itemsById[$parentId];
+            $sorted[] = $parentItem;
+            $addedIds[] = $parentId;
+        }
+
+        // Now, add the children of the current parent
+        foreach ($itemsById as $item) {
+            if ($item['parent'] === $parentId && ! in_array($item['id'], $addedIds)) {
+                $sorted[] = $item;
+                $addedIds[] = $item['id'];
+
+                // Recursively add its children
+                $this->addItemWithChildren($itemsById, $sorted, $addedIds, $item['id']);
+            }
+        }
+    }
+}

--- a/src/Transformers/EntriesTransformer.php
+++ b/src/Transformers/EntriesTransformer.php
@@ -35,6 +35,16 @@ class EntriesTransformer extends AbstractTransformer
                     $entry->set($this->config('related_field'), $value);
                 }
 
+                if ($structure = $entry->collection()->structure()) {
+                    $entry->afterSave(function ($entry) use ($structure) {
+                        $tree = $structure->in($entry->site()->handle());
+
+                        if (!$tree->find($entry->id())) {
+                            $tree->append($entry)->save();
+                        }
+                    });
+                }
+
                 $entry->save();
 
                 return $entry->id();

--- a/tests/Jobs/UpdateCollectionTreeJobTest.php
+++ b/tests/Jobs/UpdateCollectionTreeJobTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Statamic\Importer\Tests\Jobs;
+
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Structure;
+use Statamic\Importer\Facades\Import;
+use Statamic\Importer\Jobs\UpdateCollectionTreeJob;
+use Statamic\Importer\Tests\TestCase;
+use Statamic\Structures\CollectionStructure;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+
+class UpdateCollectionTreeJobTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    #[Test]
+    public function updates_the_collection_tree()
+    {
+        $collection = tap(Collection::make('pages')->structure((new CollectionStructure)->expectsRoot(true)))->save();
+
+        $one = tap(Entry::make()->collection('pages')->id('one'))->save();
+        $two = tap(Entry::make()->collection('pages')->id('two'))->save();
+        $three = tap(Entry::make()->collection('pages')->id('three'))->save();
+        $four = tap(Entry::make()->collection('pages')->id('four'))->save();
+        $five = tap(Entry::make()->collection('pages')->id('five'))->save();
+
+        $tree = $collection->structure()->in('default');
+        $tree->append($one)->append($two)->append($three)->append($four)->append($five)->save();
+
+        $import = Import::make()->id('pages')->config(['destination' => ['collection' => 'pages']]);
+
+        Cache::forever('importer.pages.parents', [
+            ['id' => 'two', 'parent' => 'one'],
+            ['id' => 'three', 'parent' => 'two'],
+            ['id' => 'four', 'parent' => 'two'],
+            ['id' => 'five', 'parent' => 'three'],
+        ]);
+
+        UpdateCollectionTreeJob::dispatch($import);
+
+        $this->assertEquals([
+            ['entry' => 'one'],
+            [
+                'entry' => 'two',
+                'children' => [
+                    ['entry' => 'three', 'children' => [['entry' => 'five']]],
+                    ['entry' => 'four']
+                ],
+            ],
+        ], $collection->structure()->in('default')->tree());
+    }
+}

--- a/tests/Jobs/UpdateCollectionTreeJobTest.php
+++ b/tests/Jobs/UpdateCollectionTreeJobTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Cache;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
-use Statamic\Facades\Structure;
 use Statamic\Importer\Facades\Import;
 use Statamic\Importer\Jobs\UpdateCollectionTreeJob;
 use Statamic\Importer\Tests\TestCase;
@@ -53,7 +52,7 @@ class UpdateCollectionTreeJobTest extends TestCase
                 'entry' => 'two',
                 'children' => [
                     ['entry' => 'three', 'children' => [['entry' => 'five']]],
-                    ['entry' => 'four']
+                    ['entry' => 'four'],
                 ],
             ],
         ], $collection->structure()->in('default')->tree());

--- a/tests/Support/SortByParentTest.php
+++ b/tests/Support/SortByParentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Statamic\Importer\Tests\Support;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Importer\Support\SortByParent;
+use Statamic\Importer\Tests\TestCase;
+
+class SortByParentTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('provideData')]
+    public function it_sorts_by_parent($input, $expected)
+    {
+        $this->assertEquals($expected, (new SortByParent)->sort($input));
+    }
+
+    public static function provideData(): array
+    {
+        return [
+            'in acceptable order' => [
+                // 1
+                // |- 2
+                // |  |- 3
+                // |  |  |- 4
+                // |  |- 5
+                // |- 6
+                [
+                    ['id' => '2', 'parent' => '1'],
+                    ['id' => '3', 'parent' => '2'],
+                    ['id' => '4', 'parent' => '3'],
+                    ['id' => '5', 'parent' => '2'],
+                    ['id' => '6', 'parent' => '1'],
+                ],
+                [
+                    ['id' => '2', 'parent' => '1'],
+                    ['id' => '3', 'parent' => '2'],
+                    ['id' => '4', 'parent' => '3'],
+                    ['id' => '5', 'parent' => '2'],
+                    ['id' => '6', 'parent' => '1'],
+                ],
+            ],
+
+            'out of order' => [
+                // 1
+                // |- 2
+                // |  |- 3
+                // |  |  |- 4
+                // |  |- 5
+                // |- 6
+                [
+                    ['id' => '6', 'parent' => '1'],
+                    ['id' => '4', 'parent' => '3'],
+                    ['id' => '3', 'parent' => '2'],
+                    ['id' => '5', 'parent' => '2'],
+                    ['id' => '2', 'parent' => '1'],
+                ],
+                [
+                    ['id' => '6', 'parent' => '1'],
+                    ['id' => '2', 'parent' => '1'],
+                    ['id' => '3', 'parent' => '2'],
+                    ['id' => '4', 'parent' => '3'],
+                    ['id' => '5', 'parent' => '2'],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request makes it possible to import parent entries, allowing you to retain your page hierarchy when migrating to Statamic.

If a mapping is configured for the "Parent" field, it'll get transformed like normal, but instead of saving to the entry's data, it'll append an array to the cache.

Then, after all the entries have been saved, the `UpdateCollectionTreeJob` job will loop through all the parents, sort them (parent entries need to be handled before their children), then the collection tree will be updated.

Closes #12.

## To Do

* [x] Add a test for the `UpdateCollectionTreeJob` listener