### PR TITLE
Fix validation error when creating an import in a multi-site

### DIFF
--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -77,7 +77,7 @@ class ImportController extends CpController
                     'type' => $request->destination_type,
                     'collection' => Arr::first($request->destination_collection),
                     'taxonomy' => Arr::first($request->destination_taxonomy),
-                    'site' => $request->destination_site,
+                    'site' => Arr::first($request->destination_site),
                 ])->filter()->all(),
             ]);
 

--- a/src/Http/Requests/CreateImportRequest.php
+++ b/src/Http/Requests/CreateImportRequest.php
@@ -57,7 +57,7 @@ class CreateImportRequest extends FormRequest
             'destination_site' => [
                 Rule::requiredIf(fn () => Site::hasMultiple() && $this->destination_type === 'entries'),
                 function (string $attribute, mixed $value, Closure $fail) {
-                    if ($value && $this->destination_collection && ! Collection::find($this->destination_collection[0])->sites()->contains($value)) {
+                    if (isset($value[0]) && $this->destination_collection && ! Collection::find($this->destination_collection[0])->sites()->contains($value[0])) {
                         $fail('The chosen collection is not available on this site.')->translate();
                     }
                 },


### PR DESCRIPTION
This pull request prevents a "The chosen collection is not available on this site" validation error from being thrown when creating a collection import in a multi-site.

This was happening because `destination_site` is an array, not a string like the validation rule was expecting.