### PR TITLE
Allow importing publish states (& any other toggle fields)

### DIFF
--- a/src/Fieldtypes/ImportMappingsFieldtype.php
+++ b/src/Fieldtypes/ImportMappingsFieldtype.php
@@ -39,9 +39,7 @@ class ImportMappingsFieldtype extends Fieldtype
     public function preProcess($data): array
     {
         return $this->fields()->map(function (Fields $fields, string $handle) use ($data) {
-            $field = $this->field()->parent()->destinationBlueprint()->field($handle);
-
-            return $fields->addValues(Arr::get($data, $field->handle(), []))->preProcess()->values()->all();
+            return $fields->addValues(Arr::get($data, $handle, []))->preProcess()->values()->all();
         })->all();
     }
 

--- a/src/Imports/Import.php
+++ b/src/Imports/Import.php
@@ -132,7 +132,14 @@ class Import
     public function destinationBlueprint(): \Statamic\Fields\Blueprint
     {
         if ($this->get('destination.type') === 'entries') {
-            return Collection::find($this->get('destination.collection'))->entryBlueprint();
+            $blueprint = Collection::find($this->get('destination.collection'))->entryBlueprint();
+
+            $blueprint->ensureField('published', [
+                'type' => 'toggle',
+                'display' => __('Published'),
+            ]);
+
+            return $blueprint;
         }
 
         if ($this->get('destination.type') === 'terms') {

--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -47,7 +47,7 @@ class ImportItemJob implements ShouldQueue
 
                 return [$fieldHandle => $value];
             })
-            ->filter()
+            ->reject(fn ($value) => is_null($value))
             ->all();
 
         match ($this->import->get('destination.type')) {

--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -29,7 +29,7 @@ class ImportItemJob implements ShouldQueue
 
     public function handle(): void
     {
-        $blueprint = $this->getBlueprint();
+        $blueprint = $this->import->destinationBlueprint();
 
         $data = collect($this->import->get('mappings'))
             ->reject(fn (array $mapping) => empty($mapping['key']))
@@ -55,21 +55,6 @@ class ImportItemJob implements ShouldQueue
             'terms' => $this->findOrCreateTerm($data),
             'users' => $this->findOrCreateUser($data),
         };
-    }
-
-    protected function getBlueprint(): Blueprint
-    {
-        if ($this->import->get('destination.type') === 'entries') {
-            return Collection::find($this->import->get('destination.collection'))->entryBlueprint();
-        }
-
-        if ($this->import->get('destination.type') === 'terms') {
-            return Taxonomy::find($this->import->get('destination.taxonomy'))->termBlueprint();
-        }
-
-        if ($this->import->get('destination.type') === 'users') {
-            return User::blueprint();
-        }
     }
 
     protected function findOrCreateEntry(array $data): void

--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -14,10 +14,8 @@ use Illuminate\Support\Str;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
-use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
-use Statamic\Fields\Blueprint;
 use Statamic\Importer\Importer;
 use Statamic\Importer\Imports\Import;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,6 +17,7 @@ class ServiceProvider extends AddonServiceProvider
         'date' => Transformers\DateTransformer::class,
         'entries' => Transformers\EntriesTransformer::class,
         'terms' => Transformers\TermsTransformer::class,
+        'toggle' => Transformers\ToggleTransformer::class,
         'users' => Transformers\UsersTransformer::class,
     ];
 

--- a/src/Transformers/ToggleTransformer.php
+++ b/src/Transformers/ToggleTransformer.php
@@ -2,10 +2,6 @@
 
 namespace Statamic\Importer\Transformers;
 
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
-use Statamic\Fieldtypes\Date as DateFieldtype;
-
 class ToggleTransformer extends AbstractTransformer
 {
     public function transform(string $value): bool

--- a/src/Transformers/ToggleTransformer.php
+++ b/src/Transformers/ToggleTransformer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Statamic\Importer\Transformers;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Statamic\Fieldtypes\Date as DateFieldtype;
+
+class ToggleTransformer extends AbstractTransformer
+{
+    public function transform(string $value): bool
+    {
+        if ($this->config('format') === 'boolean') {
+            return match ($value) {
+                '1', 'true' => true,
+                '0', 'false' => false,
+            };
+        }
+
+        if ($this->config('format') === 'string') {
+            return match (true) {
+                in_array($value, explode('|', $this->config('values.true'))) => true,
+                in_array($value, explode('|', $this->config('values.false'))) => false,
+            };
+        }
+    }
+
+    public function fieldItems(): array
+    {
+        return [
+            'format' => [
+                'type' => 'select',
+                'display' => __('Format'),
+                'instructions' => __('How is the value stored?'),
+                'options' => [
+                    'boolean' => __('As booleans'),
+                    'string' => __('As strings'),
+                ],
+                'validate' => 'required',
+            ],
+            'values' => [
+                'type' => 'array',
+                'display' => __('Values'),
+                'instructions' => __('Specify the values that represent true and false in your data. You separate multiple values with a pipe (`|`).'),
+                'mode' => 'keyed',
+                'keys' => [
+                    ['key' => 'true', 'value' => __('True')],
+                    ['key' => 'false', 'value' => __('False')],
+                ],
+                'validate' => 'required',
+                'if' => [
+                    'format' => 'string',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Transformers/ToggleTransformerTest.php
+++ b/tests/Transformers/ToggleTransformerTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Importer\Facades\Import;
 use Statamic\Importer\Tests\TestCase;
-use Statamic\Importer\Transformers\DateTransformer;
 use Statamic\Importer\Transformers\ToggleTransformer;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 

--- a/tests/Transformers/ToggleTransformerTest.php
+++ b/tests/Transformers/ToggleTransformerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Statamic\Importer\Tests\Transformers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Importer\Facades\Import;
+use Statamic\Importer\Tests\TestCase;
+use Statamic\Importer\Transformers\DateTransformer;
+use Statamic\Importer\Transformers\ToggleTransformer;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+
+class ToggleTransformerTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    public $collection;
+    public $blueprint;
+    public $import;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->collection = tap(Collection::make('pages'))->save();
+
+        $this->blueprint = $this->collection->entryBlueprint();
+        $this->blueprint->ensureField('featured', ['type' => 'toggle']);
+
+        $this->import = Import::make();
+    }
+
+    #[Test]
+    public function it_transforms_booleans()
+    {
+        $transformer = new ToggleTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->blueprint->field('featured'),
+            config: ['format' => 'boolean']
+        );
+
+        $this->assertTrue($transformer->transform('1'));
+        $this->assertTrue($transformer->transform('true'));
+
+        $this->assertFalse($transformer->transform('0'));
+        $this->assertFalse($transformer->transform('false'));
+    }
+
+    #[Test]
+    public function it_transforms_strings()
+    {
+        $transformer = new ToggleTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->blueprint->field('featured'),
+            config: ['format' => 'string', 'values' => ['true' => 'yes|aye|yep', 'false' => 'no']]
+        );
+
+        $this->assertTrue($transformer->transform('yes'));
+        $this->assertTrue($transformer->transform('aye'));
+        $this->assertTrue($transformer->transform('yep'));
+
+        $this->assertFalse($transformer->transform('no'));
+    }
+}


### PR DESCRIPTION
This pull request makes it possible to import publish states (& any other toggle fields).

You'll need to specify how the data is saved (either as booleans, or strings). When they're saved as strings, you'll be able to specify which string should map to true, and which should map to false.

![CleanShot 2024-11-07 at 18 42 18](https://github.com/user-attachments/assets/62e5ebef-e17f-471f-aa72-3e3a57210fab)

Closes #10.

## To Do
* Figure out why our ensured `published` field is being saved onto the original blueprint 
  * It's *probably* happening in our `BardTransformer` when we enable Bard buttons / add sets.