### PR TITLE
Allow selecting a folder for downloaded assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^5.0",
+        "statamic/cms": "^5.38",
         "spatie/simple-excel": "^3.7",
         "symfony/dom-crawler": "^7.1",
         "pixelfear/composer-dist-plugin": "^0.1.5",

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -5,12 +5,10 @@ namespace Statamic\Importer\Transformers;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Statamic\Assets\AssetUploader;
-use Statamic\Assets\Uploader;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Path;
-use Statamic\Forms\Uploaders\AssetsUploader;
 use Statamic\Support\Str;
 
 class AssetsTransformer extends AbstractTransformer

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -2,8 +2,15 @@
 
 namespace Statamic\Importer\Transformers;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
+use Statamic\Assets\AssetUploader;
+use Statamic\Assets\Uploader;
+use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
+use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
+use Statamic\Facades\Path;
+use Statamic\Forms\Uploaders\AssetsUploader;
 use Statamic\Support\Str;
 
 class AssetsTransformer extends AbstractTransformer
@@ -34,14 +41,44 @@ class AssetsTransformer extends AbstractTransformer
                     return null;
                 }
 
-                $assetContainer->disk()->put($path, $request->body());
-                $asset = tap($assetContainer->makeAsset($path))->save();
+                $asset = Asset::make()
+                    ->container($assetContainer)
+                    ->path($this->assetPath($assetContainer, $path));
+
+                $assetContainer->disk()->put($asset->path(), $request->body());
+
+                $asset->save();
             }
 
             return $asset?->path();
         })->filter();
 
         return $this->field->get('max_files') === 1 ? $assets->first() : $assets->all();
+    }
+
+    private function assetPath(AssetContainerContract $assetContainer, string $path): string
+    {
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+
+        if (config('statamic.assets.lowercase')) {
+            $ext = strtolower($extension);
+        }
+
+        $filename = AssetUploader::getSafeFilename(pathinfo($path, PATHINFO_FILENAME));
+
+        $directory = $this->config('folder') ?? Str::beforeLast($path, '/');
+        $directory = ($directory === '.') ? '/' : $directory;
+
+        $path = Path::tidy($directory.'/'.$filename.'.'.$ext);
+        $path = ltrim($path, '/');
+
+        // If the file exists, we'll append a timestamp to prevent overwriting.
+        if ($assetContainer->disk()->exists($path)) {
+            $basename = $filename.'-'.Carbon::now()->timestamp.'.'.$ext;
+            $path = Str::removeLeft(Path::assemble($directory, $basename), '/');
+        }
+
+        return $path;
     }
 
     public function fieldItems(): array
@@ -69,6 +106,14 @@ class AssetsTransformer extends AbstractTransformer
                 'display' => __('Download when missing?'),
                 'instructions' => __("If the asset can't be found in the asset container, should it be downloaded?"),
                 'if' => ['related_field' => 'url'],
+            ],
+            'folder' => [
+                'type' => 'asset_folder',
+                'display' => __('Folder'),
+                'instructions' => __('By default, downloaded assets will use same folder structure as the original URL. You can specify a different folder here.'),
+                'if' => ['download_when_missing' => true],
+                'container' => $this->field->get('container'),
+                'max_items' => 1,
             ],
         ];
     }

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -36,6 +36,7 @@ class BardTransformer extends AbstractTransformer
                             'related_field' => 'url',
                             'base_url' => $this->config['assets_base_url'] ?? null,
                             'download_when_missing' => $this->config['assets_download_when_missing'] ?? false,
+                            'folder' => $this->config['assets_folder'] ?? null,
                         ]
                     );
 
@@ -102,6 +103,14 @@ class BardTransformer extends AbstractTransformer
                     'type' => 'toggle',
                     'display' => __('Download assets when missing?'),
                     'instructions' => __("If the asset can't be found in the asset container, should it be downloaded?"),
+                ],
+                'assets_folder' => [
+                    'type' => 'asset_folder',
+                    'display' => __('Folder'),
+                    'instructions' => __('By default, downloaded assets will use same folder structure as the original URL. You can specify a different folder here.'),
+                    'if' => ['assets_download_when_missing' => true],
+                    'container' => $this->field->get('container'),
+                    'max_items' => 1,
                 ],
             ];
         }

--- a/src/WordPress/Gutenberg.php
+++ b/src/WordPress/Gutenberg.php
@@ -71,8 +71,9 @@ class Gutenberg
                         field: new Field('image', ['container' => $field->get('container'), 'max_files' => 1]),
                         config: [
                             'related_field' => 'url',
-                            'base_url' => $config['assets_base_url'] ?? null,
+                            'base_url' => $config['assets_base_url'],
                             'download_when_missing' => $config['assets_download_when_missing'] ?? false,
+                            'folder' => $config['assets_folder'] ?? null,
                         ]
                     );
 
@@ -127,6 +128,7 @@ class Gutenberg
                                                 'related_field' => 'url',
                                                 'base_url' => $config['assets_base_url'] ?? null,
                                                 'download_when_missing' => $config['assets_download_when_missing'] ?? false,
+                                                'folder' => $config['assets_folder'] ?? null,
                                             ]
                                         );
 

--- a/tests/Transformers/BardTransformerTest.php
+++ b/tests/Transformers/BardTransformerTest.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Importer\Tests\Transformers;
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\AssetContainer;
@@ -154,5 +156,100 @@ HTML);
                 ],
             ],
         ], $output);
+    }
+
+    #[Test]
+    public function it_downloads_images()
+    {
+        AssetContainer::make('assets')->disk('public')->save();
+
+        Http::fake([
+            'https://example.com/wp-content/uploads/2024/10/image.png' => Http::response(UploadedFile::fake()->image('image.png')->size(100)->get()),
+        ]);
+
+        Storage::disk('public')->assertMissing('2024/10/image.png');
+
+        $transformer = new BardTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->field,
+            config: [
+                'assets_base_url' => 'https://example.com/wp-content/uploads',
+                'assets_download_when_missing' => true,
+            ]
+        );
+
+        $output = $transformer->transform(<<<'HTML'
+<p>Nam voluptatem rem molestiae cumque doloremque. <strong>Saepe animi deserunt</strong> Maxime iam et inventore. ipsam in dignissimos qui occaecati.</p>
+<img src="https://example.com/wp-content/uploads/2024/10/image.png" />
+HTML);
+
+        $this->assertEquals([
+            [
+                'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
+                'content' => [
+                    ['type' => 'text', 'text' => 'Nam voluptatem rem molestiae cumque doloremque. '],
+                    ['type' => 'text', 'text' => 'Saepe animi deserunt', 'marks' => [['type' => 'bold']]],
+                    ['type' => 'text', 'text' => ' Maxime iam et inventore. ipsam in dignissimos qui occaecati.'],
+                ],
+            ],
+            [
+                'type' => 'image',
+                'attrs' => [
+                    'src' => 'assets::2024/10/image.png',
+                ],
+            ],
+        ], $output);
+
+        Storage::disk('public')->assertExists('2024/10/image.png');
+    }
+
+    #[Test]
+    public function it_downloads_images_and_stores_them_in_configured_folder()
+    {
+        AssetContainer::make('assets')->disk('public')->save();
+
+        Http::fake([
+            'https://example.com/wp-content/uploads/2024/10/image.png' => Http::response(UploadedFile::fake()->image('image.png')->size(100)->get()),
+        ]);
+
+        Storage::disk('public')->assertMissing('2024/10/image.png');
+
+        $transformer = new BardTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->field,
+            config: [
+                'assets_base_url' => 'https://example.com/wp-content/uploads',
+                'assets_download_when_missing' => true,
+                'assets_folder' => 'custom-folder',
+            ]
+        );
+
+        $output = $transformer->transform(<<<'HTML'
+<p>Nam voluptatem rem molestiae cumque doloremque. <strong>Saepe animi deserunt</strong> Maxime iam et inventore. ipsam in dignissimos qui occaecati.</p>
+<img src="https://example.com/wp-content/uploads/2024/10/image.png" />
+HTML);
+
+        $this->assertEquals([
+            [
+                'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
+                'content' => [
+                    ['type' => 'text', 'text' => 'Nam voluptatem rem molestiae cumque doloremque. '],
+                    ['type' => 'text', 'text' => 'Saepe animi deserunt', 'marks' => [['type' => 'bold']]],
+                    ['type' => 'text', 'text' => ' Maxime iam et inventore. ipsam in dignissimos qui occaecati.'],
+                ],
+            ],
+            [
+                'type' => 'image',
+                'attrs' => [
+                    'src' => 'assets::custom-folder/image.png',
+                ],
+            ],
+        ], $output);
+
+        Storage::disk('public')->assertExists('custom-folder/image.png');
     }
 }


### PR DESCRIPTION
This pull request adds the ability to select a folder downloaded assets should be placed in when they're downloaded.

Closes #15.
Requires statamic/cms#11099.