### PR TITLE
Parse JSON arrays as relationship values

### DIFF
--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -17,6 +17,11 @@ class AssetsTransformer extends AbstractTransformer
         $baseUrl = $this->config('base_url');
         $relatedField = $this->config('related_field', 'path');
 
+        // When $value is a JSON string, decode it.
+        if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {
+            $value = collect(json_decode($value, true))->join('|');
+        }
+
         $assets = collect(explode('|', $value))->map(function ($path) use ($assetContainer, $relatedField, $baseUrl) {
             $path = Str::of($path)
                 ->when($relatedField === 'url' && $baseUrl, function ($str) use ($baseUrl) {

--- a/src/Transformers/EntriesTransformer.php
+++ b/src/Transformers/EntriesTransformer.php
@@ -17,6 +17,11 @@ class EntriesTransformer extends AbstractTransformer
             $value = collect(unserialize($value))->join('|');
         }
 
+        // When $value is a JSON string, decode it.
+        if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {
+            $value = collect(json_decode($value, true))->join('|');
+        }
+
         if ($this->config('related_field') === 'id') {
             return is_string($value) ? explode('|', $value) : $value;
         }

--- a/src/Transformers/TermsTransformer.php
+++ b/src/Transformers/TermsTransformer.php
@@ -11,6 +11,11 @@ class TermsTransformer extends AbstractTransformer
 {
     public function transform(string $value): null|string|array
     {
+        // When $value is a JSON string, decode it.
+        if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {
+            $value = collect(json_decode($value, true))->join('|');
+        }
+
         $terms = collect(explode('|', $value))->map(function ($value) {
             $term = Term::query()
                 ->whereIn('taxonomy', Arr::wrap($this->field->get('taxonomies')))

--- a/src/Transformers/UsersTransformer.php
+++ b/src/Transformers/UsersTransformer.php
@@ -3,11 +3,17 @@
 namespace Statamic\Importer\Transformers;
 
 use Statamic\Facades\User;
+use Statamic\Support\Str;
 
 class UsersTransformer extends AbstractTransformer
 {
     public function transform(string $value): null|string|array
     {
+        // When $value is a JSON string, decode it.
+        if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {
+            $value = collect(json_decode($value, true))->join('|');
+        }
+
         if ($this->config('related_field') === 'id') {
             if (is_string($value)) {
                 return explode('|', $value);


### PR DESCRIPTION
This pull request adds support for JSON arrays being passed to the built-in relationship transformers (entries, terms & users).