### PR TITLE
Add support for Dictionary fields

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,10 +11,11 @@ use Statamic\Providers\AddonServiceProvider;
 
 class ServiceProvider extends AddonServiceProvider
 {
-    public array $transformers = [
+    protected array $transformers = [
         'assets' => Transformers\AssetsTransformer::class,
         'bard' => Transformers\BardTransformer::class,
         'date' => Transformers\DateTransformer::class,
+        'dictionary' => Transformers\DictionaryTransformer::class,
         'entries' => Transformers\EntriesTransformer::class,
         'terms' => Transformers\TermsTransformer::class,
         'toggle' => Transformers\ToggleTransformer::class,

--- a/src/Transformers/DictionaryTransformer.php
+++ b/src/Transformers/DictionaryTransformer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Statamic\Importer\Transformers;
+
+use Statamic\Dictionaries\Dictionary;
+use Statamic\Facades;
+use Statamic\Support\Str;
+
+class DictionaryTransformer extends AbstractTransformer
+{
+    public function transform(string $value): null|string|array
+    {
+        // When $value is a JSON string, decode it.
+        if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {
+            $value = collect(json_decode($value, true))->join('|');
+        }
+
+        $options = collect(explode('|', $value))->map(function ($value) {
+            return $this->dictionary()->get($value)?->value();
+        })->filter()->values();
+
+        return $this->field->get('max_items') === 1 ? $options->first() : $options->all();
+    }
+
+    private function dictionary(): Dictionary
+    {
+        $dictionary = $this->field->get('dictionary');
+
+        if (is_string($dictionary)) {
+            return Facades\Dictionary::find($dictionary);
+        }
+
+        return Facades\Dictionary::find($dictionary['type']);
+    }
+}

--- a/tests/Transformers/DictionaryTransformerTest.php
+++ b/tests/Transformers/DictionaryTransformerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Statamic\Importer\Tests\Transformers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\User;
+use Statamic\Importer\Facades\Import;
+use Statamic\Importer\Tests\TestCase;
+use Statamic\Importer\Transformers\DictionaryTransformer;
+use Statamic\Importer\Transformers\UsersTransformer;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+
+class DictionaryTransformerTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    public $collection;
+    public $blueprint;
+    public $field;
+    public $import;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->collection = tap(Collection::make('pages'))->save();
+
+        $this->blueprint = $this->collection->entryBlueprint();
+        $this->blueprint->ensureField('countries', ['type' => 'dictionary', 'dictionary' => 'countries'])->save();
+
+        $this->field = $this->blueprint->field('countries');
+
+        $this->import = Import::make();
+    }
+
+    #[Test]
+    public function it_returns_keys()
+    {
+        $transformer = new DictionaryTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->field,
+            config: []
+        );
+
+        $output = $transformer->transform('USA|CAN|FOO|DEU|GBR');
+
+        $this->assertEquals(['USA', 'CAN', 'DEU', 'GBR'], $output);
+    }
+}

--- a/tests/Transformers/DictionaryTransformerTest.php
+++ b/tests/Transformers/DictionaryTransformerTest.php
@@ -4,11 +4,9 @@ namespace Statamic\Importer\Tests\Transformers;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
-use Statamic\Facades\User;
 use Statamic\Importer\Facades\Import;
 use Statamic\Importer\Tests\TestCase;
 use Statamic\Importer\Transformers\DictionaryTransformer;
-use Statamic\Importer\Transformers\UsersTransformer;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
 class DictionaryTransformerTest extends TestCase


### PR DESCRIPTION
This pull request adds support for Dictionary fields.

Technically, you could import dictionary fields before, but you wouldn't be able to import multiple options and it didn't filter out invalid options.

Closes #36.