### PR TITLE
Update GitHub Actions Testing Workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3]
-        laravel: [10.*, 11.*]
+        laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,18 +6,31 @@ on:
 
 jobs:
   php_tests:
-    if: "!contains(github.event.head_commit.message, 'changelog')"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        php: [8.3, 8.2]
+        php: [8.2, 8.3]
         laravel: [10.*, 11.*]
-        statamic: [^5.0]
+        stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
+        include:
+          - os: windows-latest
+            php: 8.3
+            laravel: 10.*
+            stability: prefer-stable
+          - os: windows-latest
+            php: 8.3
+            laravel: 11.*
+            stability: prefer-stable
+          - os: windows-latest
+            php: 8.4
+            laravel: 11.*
+            stability: prefer-stable
 
-    name: ${{ matrix.php }} - ${{ matrix.statamic }} - ${{ matrix.laravel }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -31,8 +44,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" --no-interaction --no-update
-          composer install --no-interaction
+          composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,6 @@ jobs:
         include:
           - os: windows-latest
             php: 8.3
-            laravel: 10.*
-            stability: prefer-stable
-          - os: windows-latest
-            php: 8.3
             laravel: 11.*
             stability: prefer-stable
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
 
       - name: Install dependencies
         run: |

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "statamic/cms": "^5.38",
         "spatie/simple-excel": "^3.7",
         "symfony/dom-crawler": "^7.1",
-        "pixelfear/composer-dist-plugin": "^0.1.5"
+        "pixelfear/composer-dist-plugin": "^0.1.5",
+        "symfony/css-selector": "^7.1"
     },
     "require-dev": {
         "laravel/pint": "^1.18",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         "statamic/cms": "^5.38",
         "spatie/simple-excel": "^3.7",
         "symfony/dom-crawler": "^7.1",
-        "pixelfear/composer-dist-plugin": "^0.1.5",
-        "laravel/framework": "11.*"
+        "pixelfear/composer-dist-plugin": "^0.1.5"
     },
     "require-dev": {
         "laravel/pint": "^1.18",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "spatie/simple-excel": "^3.7",
         "symfony/dom-crawler": "^7.1",
         "pixelfear/composer-dist-plugin": "^0.1.5",
-        "symfony/css-selector": "^7.1"
+        "symfony/css-selector": "^7.1",
+        "laravel/framework": "11.*"
     },
     "require-dev": {
         "laravel/pint": "^1.18",


### PR DESCRIPTION
This pull request updates the GitHub Actions testing workflow, making various changes:

* Running tests on Windows
* Testing against `prefer-lowest` and `prefer-stable` versions
* Removes our Laravel 10 tests, since we currently only support Laravel 11