### PR TITLE
Filter out null values when saving mappings

### DIFF
--- a/src/Fieldtypes/ImportMappingsFieldtype.php
+++ b/src/Fieldtypes/ImportMappingsFieldtype.php
@@ -53,7 +53,7 @@ class ImportMappingsFieldtype extends Fieldtype
                     return null;
                 }
 
-                return $fields->addValues($values)->process()->values()->all();
+                return $fields->addValues($values)->process()->values()->filter()->all();
             })
             ->filter()
             ->all();


### PR DESCRIPTION
 This pull request prevents `null` values being persisted when saving import mappings. 