### PR TITLE
Show warning banner when database isn't configured

### DIFF
--- a/resources/js/components/EditImportForm.vue
+++ b/resources/js/components/EditImportForm.vue
@@ -11,7 +11,7 @@
             </div>
         </div>
 
-        <div v-if="batchesTableMissing" class="text-xs border border-yellow-dark rounded p-4 bg-yellow dark:bg-dark-blue-100 dark:border-none">
+        <div v-if="batchesTableMissing" class="text-xs border border-yellow-dark rounded p-4 bg-yellow dark:bg-dark-blue-100 dark:border-none mb-6">
             <div class="font-bold mb-2">{{ __('Please run your migrations.') }}</div>
             <p v-html="__('importer::messages.migrations_needed')"></p>
         </div>

--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Importer\Http\Controllers;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
@@ -215,8 +216,12 @@ class ImportController extends CpController
 
     private function ensureJobBatchesTableExists(): bool
     {
-        if (Schema::connection(config('queue.batching.database'))->hasTable(config('queue.batching.table'))) {
-            return true;
+        try {
+            if (Schema::connection(config('queue.batching.database'))->hasTable(config('queue.batching.table'))) {
+                return true;
+            }
+        } catch (QueryException $e) {
+            return false;
         }
 
         if (app()->runningUnitTests() || app()->isProduction()) {


### PR DESCRIPTION
This pull request prevents an error from occuring when the Importer can't connect to the app's database (for example: when the SQLite database file hasn't been created).

Instead of seeing an error as soon as you go to the edit page, you'll now see a banner asking you to migrate your database, which will let you configure your application's database:

![CleanShot 2024-12-10 at 10 11 57](https://github.com/user-attachments/assets/21816035-7b5c-4aae-8285-c378b0474df4)

You'll only be able to run the import after migrating the database tables.

Combined with recent updates to the docs, these changes should make the next steps a little more obvious when you're running into database-related errors.

Related: #55