### PR TITLE
Fix error when importing structured collection without mapping parents

### DIFF
--- a/src/Jobs/UpdateCollectionTreeJob.php
+++ b/src/Jobs/UpdateCollectionTreeJob.php
@@ -30,6 +30,10 @@ class UpdateCollectionTreeJob implements ShouldQueue
             return;
         }
 
+        if (! Cache::has("importer.{$this->import->id}.parents")) {
+            return;
+        }
+
         $parents = (new SortByParent)->sort(Cache::get("importer.{$this->import->id}.parents"));
 
         collect($parents)->each(function (array $item) use ($tree) {


### PR DESCRIPTION
This pull request fixes an error when importing entries into a structured collection without mapping the "Parent" field.

Fixes #57.