### PR TITLE
Use "process source images" preset when downloading assets

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -38,7 +38,7 @@ Before importing, you will need to do some preparation:
 You can run the importer as many times as you like as you tweak the mappings. It'll update existing content and create new content as needed.
 
 #### Queueing
-If you're importing a lot of content, you may want to consider running a queue worker to handle the import in the background.
+If you're importing a lot of content or downloading a lot of assets, you may want to consider running a queue worker to handle the import in the background.
 
 Assuming you have Redis installed, you can update the `QUEUE_CONNECTION` in your `.env` file to `redis` and then run:
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -20,6 +20,7 @@ return [
     'assets_download_when_missing_instructions' => 'If the asset can\'t be found in the asset container, should it be downloaded?',
     'assets_folder_instructions' => 'By default, downloaded assets will use same folder structure as the original URL. You can specify a different folder here.',
     'assets_related_field_instructions' => 'Which field does the data reference?',
+    'assets_process_downloaded_images_instructions' => 'Should downloaded images be processed using the asset container\'s source preset?',
     'entries_create_when_missing_instructions' => 'Create the entry if it doesn\'t exist.',
     'entries_related_field_instructions' => 'Which field does the data reference?',
     'terms_create_when_missing_instructions' => 'Create the term if it doesn\'t exist.',

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -171,6 +171,14 @@ class AssetsTransformer extends AbstractTransformer
                 'display' => __('Download when missing?'),
                 'instructions' => __('importer::messages.assets_download_when_missing_instructions'),
                 'if' => ['related_field' => 'url'],
+                'width' => $assetContainer->sourcePreset() ? 50 : 100,
+            ],
+            'process_downloaded_images' => [
+                'type' => 'toggle',
+                'display' => __('Process downloaded images?'),
+                'instructions' => __('importer::messages.assets_process_downloaded_images_instructions'),
+                'if' => ['related_field' => 'url', 'download_when_missing' => true],
+                'width' => 50,
             ],
             'folder' => [
                 'type' => 'asset_folder',
@@ -199,13 +207,8 @@ class AssetsTransformer extends AbstractTransformer
             ];
         }
 
-        if ($assetContainer->sourcePreset()) {
-            $fieldItems['process_downloaded_images'] = [
-                'type' => 'toggle',
-                'display' => __('Process downloaded images?'),
-                'instructions' => __('importer::messages.assets_process_downloaded_images_instructions'),
-                'if' => ['download_when_missing' => true],
-            ];
+        if (! $assetContainer->sourcePreset()) {
+            unset($fieldItems['process_downloaded_images']);
         }
 
         return $fieldItems;

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -122,9 +122,6 @@ class AssetsTransformer extends AbstractTransformer
     /**
      * This method has been copied from Core's Uploader class. We don't need the rest of the
      * Uploader, just this method so copying it was the easiest solution.
-     *
-     * @param  UploadedFile  $file
-     * @return string
      */
     private function processSourceFile(UploadedFile $file): string
     {

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Importer\Transformers;
 
+use Facades\Statamic\Imaging\ImageValidator;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
@@ -12,7 +13,6 @@ use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Glide;
 use Statamic\Facades\Path;
-use Facades\Statamic\Imaging\ImageValidator;
 use Statamic\Importer\Sources\Csv;
 use Statamic\Importer\Sources\Xml;
 use Statamic\Support\Arr;
@@ -139,7 +139,6 @@ class AssetsTransformer extends AbstractTransformer
             return $file->getRealPath();
         }
     }
-
 
     public function fieldItems(): array
     {

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -99,7 +99,7 @@ class AssetsTransformer extends AbstractTransformer
 
     private function processAssetUsingSourcePreset($asset, string $path, string $contents): void
     {
-        Storage::disk('local')->put($tempPath = 'statamic/temp-assets/'.uniqid().'.'.Str::afterLast($path, '.'), $contents);
+        Storage::disk('local')->put($tempPath = 'statamic/temp-assets/'.Str::random().'.'.Str::afterLast($path, '.'), $contents);
 
         $uploadedFile = new UploadedFile(
             path: Storage::disk('local')->path($tempPath),

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -38,6 +38,7 @@ class BardTransformer extends AbstractTransformer
                             'base_url' => $this->config['assets_base_url'] ?? null,
                             'download_when_missing' => $this->config['assets_download_when_missing'] ?? false,
                             'folder' => $this->config['assets_folder'] ?? null,
+                            'process_downloaded_images' => $this->config['assets_process_downloaded_images'] ?? false,
                         ]
                     );
 
@@ -89,8 +90,12 @@ class BardTransformer extends AbstractTransformer
 
     public function fieldItems(): array
     {
-        if ($this->field->get('container')) {
-            return [
+        $fieldItems = [];
+
+        if ($assetContainer = $this->field->get('container')) {
+            $assetContainer = AssetContainer::find($assetContainer);
+
+            $fieldItems = [
                 'assets_base_url' => [
                     'type' => 'text',
                     'display' => __('Assets Base URL'),
@@ -106,12 +111,21 @@ class BardTransformer extends AbstractTransformer
                     'display' => __('Folder'),
                     'instructions' => __('importer::messages.assets_folder_instructions'),
                     'if' => ['assets_download_when_missing' => true],
-                    'container' => $this->field->get('container'),
+                    'container' => $assetContainer->handle(),
                     'max_items' => 1,
                 ],
             ];
+
+            if ($assetContainer->sourcePreset()) {
+                $fieldItems['assets_process_downloaded_images'] = [
+                    'type' => 'toggle',
+                    'display' => __('Process downloaded images?'),
+                    'instructions' => __('importer::messages.assets_process_downloaded_images_instructions'),
+                    'if' => ['assets_download_when_missing' => true],
+                ];
+            }
         }
 
-        return [];
+        return $fieldItems;
     }
 }

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -105,6 +105,14 @@ class BardTransformer extends AbstractTransformer
                     'type' => 'toggle',
                     'display' => __('Download assets when missing?'),
                     'instructions' => __('importer::messages.assets_download_when_missing_instructions'),
+                    'width' => $assetContainer->sourcePreset() ? 50 : 100,
+                ],
+                'assets_process_downloaded_images' => [
+                    'type' => 'toggle',
+                    'display' => __('Process downloaded images?'),
+                    'instructions' => __('importer::messages.assets_process_downloaded_images_instructions'),
+                    'if' => ['assets_download_when_missing' => true],
+                    'width' => 50,
                 ],
                 'assets_folder' => [
                     'type' => 'asset_folder',
@@ -116,13 +124,8 @@ class BardTransformer extends AbstractTransformer
                 ],
             ];
 
-            if ($assetContainer->sourcePreset()) {
-                $fieldItems['assets_process_downloaded_images'] = [
-                    'type' => 'toggle',
-                    'display' => __('Process downloaded images?'),
-                    'instructions' => __('importer::messages.assets_process_downloaded_images_instructions'),
-                    'if' => ['assets_download_when_missing' => true],
-                ];
+            if (! $assetContainer->sourcePreset()) {
+                unset($fieldItems['assets_process_downloaded_images']);
             }
         }
 

--- a/src/WordPress/Gutenberg.php
+++ b/src/WordPress/Gutenberg.php
@@ -75,6 +75,7 @@ class Gutenberg
                             'base_url' => $config['assets_base_url'],
                             'download_when_missing' => $config['assets_download_when_missing'] ?? false,
                             'folder' => $config['assets_folder'] ?? null,
+                            'process_downloaded_images' => $config['assets_process_downloaded_images'] ?? false,
                         ]
                     );
 
@@ -130,6 +131,7 @@ class Gutenberg
                                                 'base_url' => $config['assets_base_url'] ?? null,
                                                 'download_when_missing' => $config['assets_download_when_missing'] ?? false,
                                                 'folder' => $config['assets_folder'] ?? null,
+                                                'process_downloaded_images' => $config['assets_process_downloaded_images'] ?? false,
                                             ]
                                         );
 

--- a/tests/Transformers/AssetsTransformerTest.php
+++ b/tests/Transformers/AssetsTransformerTest.php
@@ -6,7 +6,6 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;

--- a/tests/Transformers/AssetsTransformerTest.php
+++ b/tests/Transformers/AssetsTransformerTest.php
@@ -241,7 +241,7 @@ class AssetsTransformerTest extends TestCase
 
         Str::createRandomStringsUsing(fn () => 'temp');
 
-        File::ensureDirectoryExists(storage_path('statamic/glide/tmp'));
+        File::ensureDirectoryExists(storage_path('statamic/glide/tmp/temp.png/random'));
         File::put(storage_path('statamic/glide/tmp/temp.png/random/temp.png'), 'Transformed Image');
 
         Glide::shouldReceive('server')->once()->andReturnSelf();


### PR DESCRIPTION
This pull request allows for images to be processed using the "Process source images" preset when downloading assets.

Closes #14.