### PR TITLE
Add "Blueprint" option when configuring entry/term imports

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -5,6 +5,7 @@ return [
     'utility_description' => 'Import entries, taxonomies, and users from XML and CSV files.',
 
     'configuration_instructions' => 'You can add or modify your Blueprint fields to customize what data is imported and what fieldtype it will be stored in. You can save, refresh, and come back to this import config later until it\'s ready to run.',
+    'destination_blueprint_instructions' => 'Select which blueprint should be used for imported content.',
     'destination_collection_instructions' => 'Select the collection to import entries into.',
     'destination_site_instructions' => 'Which site should the entries be imported into?',
     'destination_taxonomy_instructions' => 'Select the taxonomy to import terms into.',

--- a/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
+++ b/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
@@ -1,10 +1,10 @@
 <template>
     <v-select
+        searchable
         :options="options"
         :get-option-label="(option) => option.title"
         :get-option-key="(option) => option.handle"
         :value="value"
-        :searchable="false"
         :reduce="opt => opt.handle"
         @input="update($event)"
     />

--- a/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
+++ b/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
@@ -1,0 +1,57 @@
+<template>
+    <v-select
+        :options="options"
+        :get-option-label="(option) => option.title"
+        :get-option-key="(option) => option.handle"
+        :value="value"
+        :searchable="false"
+        :reduce="opt => opt.handle"
+        @input="update($event)"
+    />
+</template>
+
+<script>
+export default {
+    mixins: [Fieldtype],
+
+    inject: ['storeName'],
+
+    computed: {
+        type() {
+            return this.$store.state.publish[this.storeName].values.destination.type;
+        },
+
+        collection() {
+            return this.$store.state.publish[this.storeName].values.destination.collection[0];
+        },
+
+        taxonomy() {
+            return this.$store.state.publish[this.storeName].values.destination.taxonomy[0];
+        },
+
+        options() {
+            if (this.type === 'entries') {
+                return this.meta.collectionBlueprints[this.collection];
+            }
+
+            if (this.type === 'terms') {
+                return this.meta.taxonomyBlueprints[this.taxonomy];
+            }
+        },
+    },
+
+    watch: {
+        type() {
+            this.$emit('input', null);
+        },
+
+        collection() {
+            this.$emit('input', null);
+        },
+
+        taxonomy() {
+            this.$emit('input', null);
+        },
+    }
+}
+</script>

--- a/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
+++ b/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
@@ -16,6 +16,12 @@ export default {
 
     inject: ['storeName'],
 
+    mounted() {
+        if (! this.value && this.type && (this.collection || this.taxonomy)) {
+            this.$emit('input', this.options[0].handle);
+        }
+    },
+
     computed: {
         type() {
             return this.$store.state.publish[this.storeName].values.destination.type;

--- a/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
+++ b/resources/js/components/Fieldtypes/BlueprintFieldtype.vue
@@ -46,11 +46,11 @@ export default {
         },
 
         collection() {
-            this.$emit('input', null);
+            this.$emit('input', this.options[0].handle);
         },
 
         taxonomy() {
-            this.$emit('input', null);
+            this.$emit('input', this.options[0].handle);
         },
     }
 }

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,9 +1,11 @@
 import CreateImportForm from "./components/CreateImportForm.vue";
 import EditImportForm from "./components/EditImportForm.vue";
 import ImportsListing from "./components/ImportsListing.vue";
+import BlueprintFieldtype from "./components/Fieldtypes/BlueprintFieldtype.vue";
 import ImportMappingsFieldtype from "./components/Fieldtypes/ImportMappingsFieldtype.vue";
 
 Statamic.$components.register('create-import-form', CreateImportForm);
 Statamic.$components.register('edit-import-form', EditImportForm);
 Statamic.$components.register('imports-listing', ImportsListing);
+Statamic.$components.register('blueprint-fieldtype', BlueprintFieldtype);
 Statamic.$components.register('import_mappings-fieldtype', ImportMappingsFieldtype);

--- a/src/Fieldtypes/BlueprintFieldtype.php
+++ b/src/Fieldtypes/BlueprintFieldtype.php
@@ -20,4 +20,3 @@ class BlueprintFieldtype extends Fieldtype
         ];
     }
 }
-

--- a/src/Fieldtypes/BlueprintFieldtype.php
+++ b/src/Fieldtypes/BlueprintFieldtype.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Importer\Fieldtypes;
+
+use Statamic\Facades\Collection;
+use Statamic\Facades\Taxonomy;
+use Statamic\Fields\Fieldtype;
+
+class BlueprintFieldtype extends Fieldtype
+{
+    public function preload()
+    {
+        return [
+            'collectionBlueprints' => Collection::all()->mapWithKeys(function ($collection) {
+                return [$collection->handle() => $collection->entryBlueprints()->values()];
+            })->all(),
+            'taxonomyBlueprints' => Taxonomy::all()->mapWithKeys(function ($taxonomy) {
+                return [$taxonomy->handle() => $taxonomy->termBlueprints()->values()];
+            })->all(),
+        ];
+    }
+}
+

--- a/src/Imports/Blueprint.php
+++ b/src/Imports/Blueprint.php
@@ -120,7 +120,6 @@ class Blueprint
                                                     'validate' => 'required_if:destination.type,terms',
                                                 ],
                                             ],
-                                            // todo: think about a way to make this only show when the collection/taxonomy has more than one blueprint
                                             [
                                                 'handle' => 'blueprint',
                                                 'field' => [

--- a/src/Imports/Blueprint.php
+++ b/src/Imports/Blueprint.php
@@ -128,6 +128,7 @@ class Blueprint
                                                     'display' => __('Blueprint'),
                                                     'width' => 50,
                                                     'unless' => ['destination.type' => 'users'],
+                                                    'validate' => 'required_unless:destination.type,users',
                                                 ],
                                             ],
                                             Site::hasMultiple() ? [

--- a/src/Imports/Blueprint.php
+++ b/src/Imports/Blueprint.php
@@ -126,6 +126,7 @@ class Blueprint
                                                 'field' => [
                                                     'type' => 'blueprint',
                                                     'display' => __('Blueprint'),
+                                                    'instructions' => __('importer::messages.destination_blueprint_instructions'),
                                                     'width' => 50,
                                                     'unless' => ['destination.type' => 'users'],
                                                     'validate' => 'required_unless:destination.type,users',

--- a/src/Imports/Blueprint.php
+++ b/src/Imports/Blueprint.php
@@ -265,6 +265,11 @@ class Blueprint
             $conditions['destination.taxonomy'] = 'contains '.$import->get('destination.taxonomy');
         }
 
+        // todo: when current blueprint is called "post", but the new one is called "external_post", this will not work because it's a contains match
+        if ($import->get('destination.blueprint')) {
+            $conditions['destination.blueprint'] = 'contains '.$import->get('destination.blueprint');
+        }
+
         if ($import->get('destination.site')) {
             $conditions['destination.site'] = 'contains '.$import->get('destination.site');
         }

--- a/src/Imports/Blueprint.php
+++ b/src/Imports/Blueprint.php
@@ -266,9 +266,8 @@ class Blueprint
             $conditions['destination.taxonomy'] = 'contains '.$import->get('destination.taxonomy');
         }
 
-        // todo: when current blueprint is called "post", but the new one is called "external_post", this will not work because it's a contains match
         if ($import->get('destination.blueprint')) {
-            $conditions['destination.blueprint'] = 'contains '.$import->get('destination.blueprint');
+            $conditions['destination.blueprint'] = 'equals '.$import->get('destination.blueprint');
         }
 
         if ($import->get('destination.site')) {

--- a/src/Imports/Blueprint.php
+++ b/src/Imports/Blueprint.php
@@ -120,6 +120,16 @@ class Blueprint
                                                     'validate' => 'required_if:destination.type,terms',
                                                 ],
                                             ],
+                                            // todo: think about a way to make this only show when the collection/taxonomy has more than one blueprint
+                                            [
+                                                'handle' => 'blueprint',
+                                                'field' => [
+                                                    'type' => 'blueprint',
+                                                    'display' => __('Blueprint'),
+                                                    'width' => 50,
+                                                    'unless' => ['destination.type' => 'users'],
+                                                ],
+                                            ],
                                             Site::hasMultiple() ? [
                                                 'handle' => 'site',
                                                 'field' => [

--- a/src/Imports/Import.php
+++ b/src/Imports/Import.php
@@ -137,8 +137,12 @@ class Import
     public function destinationBlueprint(): StatamicBlueprint
     {
         return match ($this->get('destination.type')) {
-            'entries' => Collection::find($this->get('destination.collection'))->entryBlueprint(),
-            'terms' => Taxonomy::find($this->get('destination.taxonomy'))->termBlueprint(),
+            'entries' => Collection::find($this->get('destination.collection'))
+                ->entryBlueprints()
+                ->first(fn ($blueprint) => $blueprint->handle() === $this->get('destination.blueprint')),
+            'terms' => Taxonomy::find($this->get('destination.taxonomy'))
+                ->termBlueprints()
+                ->first(fn ($blueprint) => $blueprint->handle() === $this->get('destination.blueprint')),
             'users' => User::blueprint(),
         };
     }

--- a/src/Imports/Import.php
+++ b/src/Imports/Import.php
@@ -139,10 +139,18 @@ class Import
         return match ($this->get('destination.type')) {
             'entries' => Collection::find($this->get('destination.collection'))
                 ->entryBlueprints()
-                ->first(fn ($blueprint) => $blueprint->handle() === $this->get('destination.blueprint')),
+                ->when(
+                    $this->get('destination.blueprint'),
+                    fn ($collection) => $collection->filter(fn ($blueprint) => $blueprint->handle() === $this->get('destination.blueprint'))
+                )
+                ->first(),
             'terms' => Taxonomy::find($this->get('destination.taxonomy'))
                 ->termBlueprints()
-                ->first(fn ($blueprint) => $blueprint->handle() === $this->get('destination.blueprint')),
+                ->when(
+                    $this->get('destination.blueprint'),
+                    fn ($taxonomy) => $taxonomy->filter(fn ($blueprint) => $blueprint->handle() === $this->get('destination.blueprint'))
+                )
+                ->first(),
             'users' => User::blueprint(),
         };
     }

--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -72,7 +72,10 @@ class ImportItemJob implements ShouldQueue
                 return;
             }
 
-            $entry = Entry::make()->collection($collection)->locale($site);
+            $entry = Entry::make()
+                ->collection($collection)
+                ->blueprint($this->import->get('destination.blueprint'))
+                ->locale($site);
         }
 
         if ($entry->id() && ! in_array('update', $this->import->get('strategy'))) {
@@ -126,7 +129,9 @@ class ImportItemJob implements ShouldQueue
                 return;
             }
 
-            $term = Term::make()->taxonomy($this->import->get('destination.taxonomy'));
+            $term = Term::make()
+                ->taxonomy($this->import->get('destination.taxonomy'))
+                ->blueprint($this->import->get('destination.blueprint'));
         }
 
         if (Term::find($term->id()) && ! in_array('update', $this->import->get('strategy'))) {

--- a/tests/Imports/StoreImportTest.php
+++ b/tests/Imports/StoreImportTest.php
@@ -40,6 +40,7 @@ class StoreImportTest extends TestCase
                 'destination' => [
                     'type' => 'entries',
                     'collection' => ['posts'],
+                    'blueprint' => 'post',
                 ],
                 'strategy' => ['create', 'update'],
             ])
@@ -75,6 +76,7 @@ class StoreImportTest extends TestCase
                 'destination' => [
                     'type' => 'entries',
                     'collection' => ['posts'],
+                    'blueprint' => 'post',
                     'site' => ['en'],
                 ],
                 'strategy' => ['create', 'update'],
@@ -113,6 +115,7 @@ class StoreImportTest extends TestCase
                 'destination' => [
                     'type' => 'entries',
                     'collection' => ['posts'],
+                    'blueprint' => 'post',
                     'site' => ['fr'],
                 ],
                 'strategy' => ['create', 'update'],
@@ -143,6 +146,7 @@ class StoreImportTest extends TestCase
                 'destination' => [
                     'type' => 'entries',
                     'collection' => ['posts'],
+                    'blueprint' => 'post',
                 ],
                 'strategy' => ['create', 'update'],
             ])
@@ -167,6 +171,7 @@ class StoreImportTest extends TestCase
                 'destination' => [
                     'type' => 'terms',
                     'taxonomy' => ['categories'],
+                    'blueprint' => 'post',
                 ],
                 'strategy' => ['create', 'update'],
             ])

--- a/tests/Imports/UpdateImportTest.php
+++ b/tests/Imports/UpdateImportTest.php
@@ -63,7 +63,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Old Posts',
                 'file' => ['posts.csv'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'source' => ['csv_delimiter' => ','],
                 'mappings' => [
@@ -95,7 +95,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['123456789/latest-posts.csv'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'source' => ['csv_delimiter' => ','],
                 'mappings' => [
@@ -124,7 +124,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['123456789/latest-posts.pdf'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'mappings' => [
                     'title' => ['key' => 'Title'],
@@ -155,7 +155,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['123456789/latest-posts.pdf'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'mappings' => [
                     'title' => ['key' => 'Title'],
@@ -183,7 +183,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['posts.csv'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => [],
                 'mappings' => [
                     'title' => ['key' => 'Title'],
@@ -209,7 +209,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['posts.csv'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'mappings' => [
                     'title' => ['key' => null],
@@ -231,7 +231,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['posts.csv'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'mappings' => [
                     'author' => ['key' => 'Author Email', 'related_field' => null],
@@ -249,7 +249,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['posts.csv'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'mappings' => [
                     'title' => ['key' => 'Title'],
@@ -271,7 +271,7 @@ class UpdateImportTest extends TestCase
             ->patch("/cp/utilities/importer/{$this->import->id()}", [
                 'name' => 'Posts',
                 'file' => ['posts.csv'],
-                'destination' => ['type' => 'entries', 'collection' => ['posts']],
+                'destination' => ['type' => 'entries', 'collection' => ['posts'], 'blueprint' => 'post'],
                 'strategy' => ['create', 'update'],
                 'mappings' => [
                     'title' => ['key' => 'Title'],

--- a/tests/Jobs/ImportItemJobTest.php
+++ b/tests/Jobs/ImportItemJobTest.php
@@ -3,6 +3,7 @@
 namespace Statamic\Importer\Tests\Jobs;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -150,6 +151,8 @@ class ImportItemJobTest extends TestCase
                 ],
             ],
         ])->save();
+
+        Blink::forget('collection-entry-blueprints-team');
 
         $this->assertNull(Entry::query()->where('email', 'John')->first());
 

--- a/tests/Jobs/ImportItemJobTest.php
+++ b/tests/Jobs/ImportItemJobTest.php
@@ -68,7 +68,7 @@ class ImportItemJobTest extends TestCase
         $this->assertNull(Entry::query()->where('email', 'john.doe@example.com')->first());
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'entries', 'collection' => 'team'],
+            'destination' => ['type' => 'entries', 'collection' => 'team', 'blueprint' => 'team'],
             'unique_field' => 'email',
             'mappings' => [
                 'first_name' => ['key' => 'First Name'],
@@ -108,7 +108,7 @@ class ImportItemJobTest extends TestCase
         $this->assertNull(Entry::query()->where('email', 'john.doe@example.com')->first());
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'entries', 'collection' => 'team', 'site' => 'fr'],
+            'destination' => ['type' => 'entries', 'collection' => 'team', 'blueprint' => 'team', 'site' => 'fr'],
             'unique_field' => 'email',
             'mappings' => [
                 'first_name' => ['key' => 'First Name'],
@@ -142,7 +142,7 @@ class ImportItemJobTest extends TestCase
         $this->assertNull(Entry::query()->where('email', 'john.doe@example.com')->first());
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'entries', 'collection' => 'team'],
+            'destination' => ['type' => 'entries', 'collection' => 'team', 'blueprint' => 'team'],
             'unique_field' => 'email',
             'mappings' => [
                 'first_name' => ['key' => 'First Name'],
@@ -172,7 +172,7 @@ class ImportItemJobTest extends TestCase
         $entry->save();
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'entries', 'collection' => 'team'],
+            'destination' => ['type' => 'entries', 'collection' => 'team', 'blueprint' => 'team'],
             'unique_field' => 'email',
             'mappings' => [
                 'first_name' => ['key' => 'First Name'],
@@ -213,7 +213,7 @@ class ImportItemJobTest extends TestCase
         $entry->save();
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'entries', 'collection' => 'team', 'site' => 'fr'],
+            'destination' => ['type' => 'entries', 'collection' => 'team', 'blueprint' => 'team', 'site' => 'fr'],
             'unique_field' => 'email',
             'mappings' => [
                 'first_name' => ['key' => 'First Name'],
@@ -255,7 +255,7 @@ class ImportItemJobTest extends TestCase
         $entry->save();
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'entries', 'collection' => 'team', 'site' => 'fr'],
+            'destination' => ['type' => 'entries', 'collection' => 'team', 'blueprint' => 'team', 'site' => 'fr'],
             'unique_field' => 'email',
             'mappings' => [
                 'first_name' => ['key' => 'First Name'],
@@ -301,7 +301,7 @@ class ImportItemJobTest extends TestCase
         $entry->save();
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'entries', 'collection' => 'team'],
+            'destination' => ['type' => 'entries', 'collection' => 'team', 'blueprint' => 'team'],
             'unique_field' => 'email',
             'mappings' => [
                 'first_name' => ['key' => 'First Name'],
@@ -334,7 +334,7 @@ class ImportItemJobTest extends TestCase
         $this->assertNull(Term::query()->where('title', 'Statamic')->first());
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'terms', 'taxonomy' => 'tags'],
+            'destination' => ['type' => 'terms', 'taxonomy' => 'tags', 'blueprint' => 'tag'],
             'unique_field' => 'title',
             'mappings' => [
                 'title' => ['key' => 'Title'],
@@ -359,7 +359,7 @@ class ImportItemJobTest extends TestCase
         $this->assertNull(Term::query()->where('title', 'Statamic')->first());
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'terms', 'taxonomy' => 'tags'],
+            'destination' => ['type' => 'terms', 'taxonomy' => 'tags', 'blueprint' => 'tag'],
             'unique_field' => 'title',
             'mappings' => [
                 'title' => ['key' => 'Title'],
@@ -381,7 +381,7 @@ class ImportItemJobTest extends TestCase
         $term->save();
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'terms', 'taxonomy' => 'tags'],
+            'destination' => ['type' => 'terms', 'taxonomy' => 'tags', 'blueprint' => 'tag'],
             'unique_field' => 'title',
             'mappings' => [
                 'title' => ['key' => 'Title'],
@@ -410,7 +410,7 @@ class ImportItemJobTest extends TestCase
         $term->save();
 
         $import = Import::make()->config([
-            'destination' => ['type' => 'terms', 'taxonomy' => 'tags'],
+            'destination' => ['type' => 'terms', 'taxonomy' => 'tags', 'blueprint' => 'tag'],
             'unique_field' => 'title',
             'mappings' => [
                 'title' => ['key' => 'Title'],


### PR DESCRIPTION
This pull request adds a "Blueprint" dropdown when configuring entry/term imports.

https://github.com/user-attachments/assets/136b0301-f1a9-4be1-bccb-a87afa6476b1


Closes #53.