### PR TITLE
Fix import issue with Bard

### DIFF
--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -28,6 +28,13 @@ class BardTransformer extends AbstractTransformer
 
         return collect($value)
             ->map(function (array $node): ?array {
+                if ($node['type'] === 'text') {
+                    return [
+                        'type' => 'paragraph',
+                        'content' => [$node],
+                    ];
+                }
+
                 if ($node['type'] === 'image' && $this->field->get('container') && isset($this->config['assets_base_url'])) {
                     $assetContainer = AssetContainer::find($this->field->get('container'));
 

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -54,6 +54,7 @@ class BardTransformer extends AbstractTransformer
                 return $node;
             })
             ->filter()
+            ->values()
             ->all();
     }
 


### PR DESCRIPTION
This pull request fixes an issue when importing Bard fields where if the provided HTML doesn't wrap text in `<p>` tags, it would cause the text to be in-editable in the Control Panel.

Due to the lack of `<p>` tags, ProseMirror was outputting `text` nodes. However, in order for them to be editable (& formatted properly in Bard), they need to be wrapped in `paragraph` nodes.

See an example below:

![CleanShot 2024-12-19 at 16 22 08](https://github.com/user-attachments/assets/d22caa49-a057-4fe0-bfd9-a21f3120eddf)

![image](https://github.com/user-attachments/assets/4b2c3505-1224-400f-a6a0-900ae67706ba)

This PR also fixes an issue where indexes were being outputted by the Bard transformer, which they shouldn't have been.

Fixes #62.