### PR TITLE
Fix existing asset detection

### DIFF
--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -42,7 +42,12 @@ class AssetsTransformer extends AbstractTransformer
                 ->trim('/')
                 ->__toString();
 
-            $asset = $assetContainer->asset($path);
+            $assetPath = $path;
+            if ($this->config('folder')) {
+                $assetPath = Str::ensureRight($this->config('folder'), '/').Str::afterLast($path, '/');
+            }
+
+            $asset = $assetContainer->asset($assetPath);
 
             if (! $asset && $this->config('download_when_missing') && $relatedField === 'url') {
                 $request = Http::get(Str::removeRight($baseUrl, '/').Str::ensureLeft($path, '/'));

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -43,6 +43,7 @@ class AssetsTransformer extends AbstractTransformer
                 ->__toString();
 
             $assetPath = $path;
+
             if ($this->config('folder')) {
                 $assetPath = Str::ensureRight($this->config('folder'), '/').Str::afterLast($path, '/');
             }

--- a/tests/Transformers/AssetsTransformerTest.php
+++ b/tests/Transformers/AssetsTransformerTest.php
@@ -141,6 +141,30 @@ class AssetsTransformerTest extends TestCase
     }
 
     #[Test]
+    public function it_doesnt_downloads_new_asset_when_it_already_exists_in_the_configured_folder()
+    {
+        Http::preventStrayRequests();
+
+        Storage::disk('public')->put('custom-folder/image.png', 'original');
+
+        $transformer = new AssetsTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->field,
+            config: [
+                'related_field' => 'url',
+                'base_url' => 'https://example.com/wp-content/uploads',
+                'download_when_missing' => true,
+                'folder' => 'custom-folder',
+            ]
+        );
+
+        $output = $transformer->transform('https://example.com/wp-content/uploads/2024/10/image.png');
+
+        $this->assertEquals('custom-folder/image.png', $output);
+    }
+
+    #[Test]
     public function it_doesnt_download_new_asset_when_download_when_missing_option_is_disabled()
     {
         Http::preventStrayRequests();


### PR DESCRIPTION
The folder setting of file fields does not work as expected.

Let's have a look at some example configuration:

Asset URL: `https://www.domain.tld/wp-content/uploads/2024/08/image.jpg`
Base URL: `https://www.domain.tld/wp-content/uploads/`
Folder: `images`

The asset is uploaded correctly to the configured folder `images` instead of `2024/08`. However, the check for an existent asset to prevent multiple uploads does not take the new folder into account.

Therefore, the assets will get uploaded again with a timestamp at the end on every new import run.

This PR solves the issue in a not so elegant way I believe. It works, but maybe someone could refactor it.