### PR TITLE
Only enable used Bard buttons

### DIFF
--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -3,6 +3,7 @@
 namespace Statamic\Importer\Transformers;
 
 use Facades\Statamic\Importer\Support\FieldUpdater;
+use Illuminate\Support\Collection;
 use Statamic\Facades\AssetContainer;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Bard\Augmentor as BardAugmentor;
@@ -13,20 +14,22 @@ class BardTransformer extends AbstractTransformer
 {
     public function transform(string $value): array
     {
-        $this->enableBardButtons();
-
         if ($this->isGutenbergValue($value)) {
-            return Gutenberg::toBard(
+            $value = Gutenberg::toBard(
                 config: $this->config,
                 blueprint: $this->blueprint,
                 field: $this->field,
                 value: $value
             );
+
+            $this->enableBardButtons($value);
+
+            return $value;
         }
 
         $value = (new BardAugmentor($this->field->fieldtype()))->renderHtmlToProsemirror($value)['content'];
 
-        return collect($value)
+        $value = collect($value)
             ->map(function (array $node): ?array {
                 if ($node['type'] === 'text') {
                     return [
@@ -63,32 +66,88 @@ class BardTransformer extends AbstractTransformer
             ->filter()
             ->values()
             ->all();
+
+        $this->enableBardButtons($value);
+
+        return $value;
     }
 
-    private function enableBardButtons(): void
+    private function enableBardButtons(array $value): void
     {
-        $buttons = [
-            'h1',
-            'h2',
-            'h3',
-            'bold',
-            'italic',
-            'unorderedlist',
-            'orderedlist',
-            'removeformat',
-            'quote',
-            'anchor',
-            'image',
-            'table',
-            'horizontalrule',
-            'codeblock',
-            'underline',
-            'superscript',
-        ];
+        $config = $this->field->config();
+
+        $config['buttons'] = collect($config['buttons'] ?? [])
+            ->merge($this->identifyBardButtons($value))
+            ->unique()
+            ->values()
+            ->all();
 
         FieldUpdater::field($this->field)
             ->blueprint($this->blueprint)
-            ->updateFieldConfig(array_merge($this->field->config(), ['buttons' => $buttons]));
+            ->updateFieldConfig($config);
+    }
+
+    private function identifyBardButtons(array $value): Collection
+    {
+        $buttons = collect();
+
+        collect($value)->each(function ($node) use (&$buttons) {
+            $buttons->push(match ($node['type']) {
+                'codeBlock' => 'codeblock',
+                'horizontalRule' => 'horizontalrule',
+                'image' => 'image',
+                'blockquote' => 'quote',
+                'orderedList' => 'orderedlist',
+                'bulletList' => 'unorderedlist',
+                'table' => 'table',
+                default => null,
+            });
+
+            if ($node['type'] === 'heading' && isset($node['attrs']['level'])) {
+                $buttons->push(match ($node['attrs']['level']) {
+                    1 => 'h1',
+                    2 => 'h2',
+                    3 => 'h3',
+                    4 => 'h4',
+                    5 => 'h5',
+                    6 => 'h6',
+                    default => null,
+                });
+            }
+
+            if (isset($node['attrs']['textAlign'])) {
+                $buttons->push(match ($node['attrs']['textAlign']) {
+                    'left' => 'alignleft',
+                    'center' => 'aligncenter',
+                    'right' => 'alignright',
+                    'justify' => 'alignjustify',
+                    default => null,
+                });
+            }
+
+            if (isset($node['marks'])) {
+                collect($node['marks'])->each(function ($mark) use (&$buttons) {
+                    $buttons->push(match ($mark['type']) {
+                        'link' => 'anchor',
+                        'bold' => 'bold',
+                        'italic' => 'italic',
+                        'code' => 'code',
+                        'underline' => 'underline',
+                        'strike' => 'strikethrough',
+                        'subscript' => 'subscript',
+                        'superscript' => 'superscript',
+                        'small' => 'small',
+                        default => null,
+                    });
+                });
+            }
+
+            if ($node !== 'set' && isset($node['content'])) {
+                $buttons = $buttons->merge($this->identifyBardButtons($node['content']));
+            }
+        });
+
+        return $buttons->filter()->unique()->values();
     }
 
     private function isGutenbergValue(string $value): bool

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Orchestra\Testbench\Attributes\WithMigration;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Config;
 use Statamic\Facades\Fieldset;
-use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Importer\ServiceProvider;
 use Statamic\Testing\AddonTestCase;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,10 @@
 namespace Statamic\Importer\Tests;
 
 use Orchestra\Testbench\Attributes\WithMigration;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Config;
+use Statamic\Facades\Fieldset;
+use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Importer\ServiceProvider;
 use Statamic\Testing\AddonTestCase;
@@ -12,6 +15,14 @@ use Statamic\Testing\AddonTestCase;
 abstract class TestCase extends AddonTestCase
 {
     protected string $addonServiceProvider = ServiceProvider::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['files']->deleteDirectory(Blueprint::directory());
+        $this->app['files']->deleteDirectory(Fieldset::directory());
+    }
 
     protected function getEnvironmentSetUp($app)
     {

--- a/tests/Transformers/BardTransformerTest.php
+++ b/tests/Transformers/BardTransformerTest.php
@@ -287,27 +287,15 @@ HTML);
             config: []
         );
 
-        $transformer->transform('<p>Hello world!</p>');
+        $transformer->transform('<h2 style="text-align: center;"><strong>Hello</strong> <em>world</em>!</h2>');
 
         $blueprint = $this->collection->entryBlueprint();
 
         $this->assertEquals([
-            'h1',
             'h2',
-            'h3',
+            'aligncenter',
             'bold',
             'italic',
-            'unorderedlist',
-            'orderedlist',
-            'removeformat',
-            'quote',
-            'anchor',
-            'image',
-            'table',
-            'horizontalrule',
-            'codeblock',
-            'underline',
-            'superscript',
         ], $blueprint->field('content')->get('buttons'));
     }
 
@@ -337,27 +325,15 @@ HTML);
             config: []
         );
 
-        $transformer->transform('<p>Hello world!</p>');
+        $transformer->transform('<h2 style="text-align: center;"><strong>Hello</strong> <em>world</em>!</h2>');
 
         $fieldset = Fieldset::find('content_stuff');
 
         $this->assertEquals([
-            'h1',
             'h2',
-            'h3',
+            'aligncenter',
             'bold',
             'italic',
-            'unorderedlist',
-            'orderedlist',
-            'removeformat',
-            'quote',
-            'anchor',
-            'image',
-            'table',
-            'horizontalrule',
-            'codeblock',
-            'underline',
-            'superscript',
         ], $fieldset->field('bard_field')->get('buttons'));
     }
 
@@ -387,27 +363,15 @@ HTML);
             config: []
         );
 
-        $transformer->transform('<p>Hello world!</p>');
+        $transformer->transform('<h2 style="text-align: center;"><strong>Hello</strong> <em>world</em>!</h2>');
 
         $fieldset = Fieldset::find('content_stuff');
 
         $this->assertEquals([
-            'h1',
             'h2',
-            'h3',
+            'aligncenter',
             'bold',
             'italic',
-            'unorderedlist',
-            'orderedlist',
-            'removeformat',
-            'quote',
-            'anchor',
-            'image',
-            'table',
-            'horizontalrule',
-            'codeblock',
-            'underline',
-            'superscript',
         ], $fieldset->field('bard_field')->get('buttons'));
     }
 }

--- a/tests/Transformers/EntriesTransformerTest.php
+++ b/tests/Transformers/EntriesTransformerTest.php
@@ -106,7 +106,7 @@ class EntriesTransformerTest extends TestCase
 
         $blueprint = Blueprint::find($this->blueprint->fullyQualifiedHandle());
         $blueprint->ensureFieldHasConfig('other_entries', ['type' => 'entries', 'collections' => ['pages'], 'select_across_sites' => true]);
-        
+
         $this->field = $blueprint->field('other_entries');
 
         Entry::make()->collection('pages')->locale('de')->id('ein')->set('title', 'Entry Ein')->save();

--- a/tests/Transformers/EntriesTransformerTest.php
+++ b/tests/Transformers/EntriesTransformerTest.php
@@ -3,6 +3,7 @@
 namespace Statamic\Importer\Tests\Transformers;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Importer\Facades\Import;
@@ -103,8 +104,10 @@ class EntriesTransformerTest extends TestCase
 
         $this->import->config(['destination' => ['site' => 'de']]);
 
-        $this->blueprint->ensureFieldHasConfig('other_entries', ['type' => 'entries', 'collections' => ['pages'], 'select_across_sites' => true]);
-        $this->field = $this->blueprint->field('other_entries');
+        $blueprint = Blueprint::find($this->blueprint->fullyQualifiedHandle());
+        $blueprint->ensureFieldHasConfig('other_entries', ['type' => 'entries', 'collections' => ['pages'], 'select_across_sites' => true]);
+        
+        $this->field = $blueprint->field('other_entries');
 
         Entry::make()->collection('pages')->locale('de')->id('ein')->set('title', 'Entry Ein')->save();
         Entry::make()->collection('pages')->locale('de')->id('zwei')->set('title', 'Entry Zwei')->save();
@@ -112,7 +115,7 @@ class EntriesTransformerTest extends TestCase
 
         $transformer = new EntriesTransformer(
             import: $this->import,
-            blueprint: $this->blueprint,
+            blueprint: $blueprint,
             field: $this->field,
             config: ['related_field' => 'title']
         );


### PR DESCRIPTION
Currently, when you import a Bard field, the importer will automatically enable various Buttons on the Bard field, so you don't see errors like this when viewing imported entries in the Control Panel:

![CleanShot 2025-01-06 at 18 15 57](https://github.com/user-attachments/assets/bdad9076-71aa-463c-8665-ea1201b9000f)

This was fine. It meant you didn't encounter those errors - well, unless your content needed a button that wasn't enabled by default, in which case you'd need to enable the button manually.

However, it always felt a bit janky, especially if your imported content only needed something like bold or italic, but we also enabled images for you.

This pull request improves it, by only enabling the buttons needed for the content you've imported. 

Closes #72.