### PR TITLE
Date Ranges

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -22,6 +22,8 @@ return [
     'assets_folder_instructions' => 'By default, downloaded assets will use same folder structure as the original URL. You can specify a different folder here.',
     'assets_related_field_instructions' => 'Which field does the data reference?',
     'assets_process_downloaded_images_instructions' => 'Should downloaded images be processed using the asset container\'s source preset?',
+    'date_start_date_instructions' => 'Which field should be used for the start date?',
+    'date_end_date_instructions' => 'Which field should be used for the end date?',
     'entries_create_when_missing_instructions' => 'Create the entry if it doesn\'t exist.',
     'entries_related_field_instructions' => 'Which field does the data reference?',
     'terms_create_when_missing_instructions' => 'Create the term if it doesn\'t exist.',

--- a/src/Transformers/DateTransformer.php
+++ b/src/Transformers/DateTransformer.php
@@ -4,10 +4,26 @@ namespace Statamic\Importer\Transformers;
 
 use Illuminate\Support\Carbon;
 use Statamic\Fieldtypes\Date as DateFieldtype;
+use Statamic\Importer\Sources\Csv;
+use Statamic\Importer\Sources\Xml;
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class DateTransformer extends AbstractTransformer
 {
-    public function transform(string $value): int|string
+    public function transform(string $value): array|int|string
+    {
+        if ($this->field->get('mode') === 'range') {
+            return [
+                'start' => $this->transformDate($value),
+                'end' => $this->transformDate(Arr::get($this->values, $this->config('end'))),
+            ];
+        }
+
+        return $this->transformDate($value);
+    }
+
+    private function transformDate(string $value): int|string
     {
         $date = Carbon::parse($value);
 
@@ -31,5 +47,40 @@ class DateTransformer extends AbstractTransformer
         }
 
         return DateFieldtype::DEFAULT_DATE_FORMAT;
+    }
+
+    public function fieldItems(): array
+    {
+        if ($this->field->get('mode') === 'range') {
+            $row = match ($this->import?->get('type')) {
+                'csv' => (new Csv($this->import))->getItems($this->import->get('path'))->first(),
+                'xml' => (new Xml($this->import))->getItems($this->import->get('path'))->first(),
+            };
+
+            // To prevent the field mapping from being filtered out, the Start Date is the "normal" key,
+            // and the End Date is a config option.
+            return [
+                'key' => [
+                    'type' => 'select',
+                    'display' => __('Start'),
+                    'instructions' => __('importer::messages.date_start_date_instructions'),
+                    'options' => collect($row)->map(fn ($value, $key) => [
+                        'key' => $key,
+                        'value' => "<{$key}>: ".Str::truncate($value, 200),
+                    ])->values()->all(),
+                ],
+                'end' => [
+                    'type' => 'select',
+                    'display' => __('End'),
+                    'instructions' => __('importer::messages.date_end_date_instructions'),
+                    'options' => collect($row)->map(fn ($value, $key) => [
+                        'key' => $key,
+                        'value' => "<{$key}>: ".Str::truncate($value, 200),
+                    ])->values()->all(),
+                ],
+            ];
+        }
+
+        return [];
     }
 }

--- a/tests/Transformers/DateTransformerTest.php
+++ b/tests/Transformers/DateTransformerTest.php
@@ -81,12 +81,8 @@ class DateTransformerTest extends TestCase
             import: $this->import,
             blueprint: $this->blueprint,
             field: $this->blueprint->field('the_date'),
-            config: [
-                'end' => 'The End Date',
-            ],
-            values: [
-                'The End Date' => '2023-12-20',
-            ]
+            config: ['end' => 'The End Date'],
+            values: ['The End Date' => '2023-12-20']
         );
 
         $this->assertEquals([

--- a/tests/Transformers/DateTransformerTest.php
+++ b/tests/Transformers/DateTransformerTest.php
@@ -71,4 +71,27 @@ class DateTransformerTest extends TestCase
 
         $this->assertEquals('31st October 2024', $transformer->transform('2024-10-31'));
     }
+
+    #[Test]
+    public function it_transforms_date_range()
+    {
+        $this->blueprint->ensureField('the_date', ['type' => 'date', 'mode' => 'range', 'time_enabled' => false]);
+
+        $transformer = new DateTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->blueprint->field('the_date'),
+            config: [
+                'end' => 'The End Date',
+            ],
+            values: [
+                'The End Date' => '2023-12-20',
+            ]
+        );
+
+        $this->assertEquals([
+            'start' => '2023-10-02',
+            'end' => '2023-12-20',
+        ], $transformer->transform('2023-10-02'));
+    }
 }


### PR DESCRIPTION
This pull request adds support for importing Date Range fields.

![CleanShot 2025-01-07 at 12 24 51](https://github.com/user-attachments/assets/e3a25296-52c1-4d3b-acbb-08275074655a)

To prevent the field mapping from being filtered out, the "Start Date" option uses the `key` under the hood, and the "End Date" is just a normal config option.

Closes #68.