### PR TITLE
Fix formatting issues from WordPress' Classic Editor

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -89,6 +89,9 @@ While you *can* use WordPress' built-in export tool, it doesn't contain all the 
 
 Instead, we recommend using a plugin like [WP All Export](https://wordpress.org/plugins/wp-all-export/) to export your content. It allows you to customize the columns included in the export (like ACF fields, featured images, etc.) and it'll give you a CSV.
 
+### Classic Editor
+If you're importing content from the Classic Editor into a [Bard field](https://statamic.dev/fieldtypes/bard#overview), you will likely want to enable the "WordPress: Replace double line-breaks with <p> tags" option, which will wrap any unwrapped text in `<p>` tags before importing it into Bard.
+
 ### Gutenberg
 Statamic's [Bard fieldtype](https://statamic.dev/fieldtypes/bard#overview) is the closest equivalent to WordPress' Gutenberg editor.
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -22,7 +22,7 @@ return [
     'assets_folder_instructions' => 'By default, downloaded assets will use same folder structure as the original URL. You can specify a different folder here.',
     'assets_related_field_instructions' => 'Which field does the data reference?',
     'assets_process_downloaded_images_instructions' => 'Should downloaded images be processed using the asset container\'s source preset?',
-    'bard_wp_auto_p_instructions' => "Replaces double line breaks with paragraph elements. If you're importing from WordPress' Classic Editor, enable this.",
+    'bard_wp_auto_p_instructions' => "You may want to enable this if you're importing from the Classic Editor.",
     'date_start_date_instructions' => 'Which field should be used for the start date?',
     'date_end_date_instructions' => 'Which field should be used for the end date?',
     'entries_create_when_missing_instructions' => 'Create the entry if it doesn\'t exist.',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -22,6 +22,7 @@ return [
     'assets_folder_instructions' => 'By default, downloaded assets will use same folder structure as the original URL. You can specify a different folder here.',
     'assets_related_field_instructions' => 'Which field does the data reference?',
     'assets_process_downloaded_images_instructions' => 'Should downloaded images be processed using the asset container\'s source preset?',
+    'bard_wp_auto_p_instructions' => "Replaces double line breaks with paragraph elements. If you're importing from WordPress' Classic Editor, enable this.",
     'date_start_date_instructions' => 'Which field should be used for the start date?',
     'date_end_date_instructions' => 'Which field should be used for the end date?',
     'entries_create_when_missing_instructions' => 'Create the entry if it doesn\'t exist.',

--- a/src/Support/WordPress.php
+++ b/src/Support/WordPress.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Statamic\Importer\Support;
+
+/**
+ * A collection of functions borrowed from WordPress to handle some of its oddities.
+ */
+class WordPress
+{
+    /**
+     * Replaces double line breaks with paragraph elements.
+     *
+     * A group of regex replaces used to identify text formatted with newlines and
+     * replace double line breaks with HTML paragraph tags. The remaining line breaks
+     * after conversion become `<br />` tags, unless `$br` is set to '0' or 'false'.
+     *
+     * @since 0.71
+     *
+     * @param string $text The text which has to be formatted.
+     * @param bool   $br   Optional. If set, this will convert all remaining line breaks
+     *                     after paragraphing. Line breaks within `<script>`, `<style>`,
+     *                     and `<svg>` tags are not affected. Default true.
+     * @return string Text which has been converted into correct paragraph tags.
+     */
+    public static function wpautop( $text, $br = true )
+    {
+        $pre_tags = array();
+
+        if ( trim( $text ) === '' ) {
+            return '';
+        }
+
+        // Just to make things a little easier, pad the end.
+        $text = $text . "\n";
+
+        /*
+         * Pre tags shouldn't be touched by autop.
+         * Replace pre tags with placeholders and bring them back after autop.
+         */
+        if ( str_contains( $text, '<pre' ) ) {
+            $text_parts = explode( '</pre>', $text );
+            $last_part  = array_pop( $text_parts );
+            $text       = '';
+            $i          = 0;
+
+            foreach ( $text_parts as $text_part ) {
+                $start = strpos( $text_part, '<pre' );
+
+                // Malformed HTML?
+                if ( false === $start ) {
+                    $text .= $text_part;
+                    continue;
+                }
+
+                $name              = "<pre wp-pre-tag-$i></pre>";
+                $pre_tags[ $name ] = substr( $text_part, $start ) . '</pre>';
+
+                $text .= substr( $text_part, 0, $start ) . $name;
+                ++$i;
+            }
+
+            $text .= $last_part;
+        }
+        // Change multiple <br>'s into two line breaks, which will turn into paragraphs.
+        $text = preg_replace( '|<br\s*/?>\s*<br\s*/?>|', "\n\n", $text );
+
+        $allblocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|style|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
+
+        // Add a double line break above block-level opening tags.
+        $text = preg_replace( '!(<' . $allblocks . '[\s/>])!', "\n\n$1", $text );
+
+        // Add a double line break below block-level closing tags.
+        $text = preg_replace( '!(</' . $allblocks . '>)!', "$1\n\n", $text );
+
+        // Add a double line break after hr tags, which are self closing.
+        $text = preg_replace( '!(<hr\s*?/?>)!', "$1\n\n", $text );
+
+        // Standardize newline characters to "\n".
+        $text = str_replace( array( "\r\n", "\r" ), "\n", $text );
+
+        // Find newlines in all elements and add placeholders.
+        $text = static::wp_replace_in_html_tags( $text, array( "\n" => ' <!-- wpnl --> ' ) );
+
+        // Collapse line breaks before and after <option> elements so they don't get autop'd.
+        if ( str_contains( $text, '<option' ) ) {
+            $text = preg_replace( '|\s*<option|', '<option', $text );
+            $text = preg_replace( '|</option>\s*|', '</option>', $text );
+        }
+
+        /*
+         * Collapse line breaks inside <object> elements, before <param> and <embed> elements
+         * so they don't get autop'd.
+         */
+        if ( str_contains( $text, '</object>' ) ) {
+            $text = preg_replace( '|(<object[^>]*>)\s*|', '$1', $text );
+            $text = preg_replace( '|\s*</object>|', '</object>', $text );
+            $text = preg_replace( '%\s*(</?(?:param|embed)[^>]*>)\s*%', '$1', $text );
+        }
+
+        /*
+         * Collapse line breaks inside <audio> and <video> elements,
+         * before and after <source> and <track> elements.
+         */
+        if ( str_contains( $text, '<source' ) || str_contains( $text, '<track' ) ) {
+            $text = preg_replace( '%([<\[](?:audio|video)[^>\]]*[>\]])\s*%', '$1', $text );
+            $text = preg_replace( '%\s*([<\[]/(?:audio|video)[>\]])%', '$1', $text );
+            $text = preg_replace( '%\s*(<(?:source|track)[^>]*>)\s*%', '$1', $text );
+        }
+
+        // Collapse line breaks before and after <figcaption> elements.
+        if ( str_contains( $text, '<figcaption' ) ) {
+            $text = preg_replace( '|\s*(<figcaption[^>]*>)|', '$1', $text );
+            $text = preg_replace( '|</figcaption>\s*|', '</figcaption>', $text );
+        }
+
+        // Remove more than two contiguous line breaks.
+        $text = preg_replace( "/\n\n+/", "\n\n", $text );
+
+        // Split up the contents into an array of strings, separated by double line breaks.
+        $paragraphs = preg_split( '/\n\s*\n/', $text, -1, PREG_SPLIT_NO_EMPTY );
+
+        // Reset $text prior to rebuilding.
+        $text = '';
+
+        // Rebuild the content as a string, wrapping every bit with a <p>.
+        foreach ( $paragraphs as $paragraph ) {
+            $text .= '<p>' . trim( $paragraph, "\n" ) . "</p>\n";
+        }
+
+        // Under certain strange conditions it could create a P of entirely whitespace.
+        $text = preg_replace( '|<p>\s*</p>|', '', $text );
+
+        // Add a closing <p> inside <div>, <address>, or <form> tag if missing.
+        $text = preg_replace( '!<p>([^<]+)</(div|address|form)>!', '<p>$1</p></$2>', $text );
+
+        // If an opening or closing block element tag is wrapped in a <p>, unwrap it.
+        $text = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $text );
+
+        // In some cases <li> may get wrapped in <p>, fix them.
+        $text = preg_replace( '|<p>(<li.+?)</p>|', '$1', $text );
+
+        // If a <blockquote> is wrapped with a <p>, move it inside the <blockquote>.
+        $text = preg_replace( '|<p><blockquote([^>]*)>|i', '<blockquote$1><p>', $text );
+        $text = str_replace( '</blockquote></p>', '</p></blockquote>', $text );
+
+        // If an opening or closing block element tag is preceded by an opening <p> tag, remove it.
+        $text = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)!', '$1', $text );
+
+        // If an opening or closing block element tag is followed by a closing <p> tag, remove it.
+        $text = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $text );
+
+        // Optionally insert line breaks.
+        if ( $br ) {
+            // Replace newlines that shouldn't be touched with a placeholder.
+            $text = preg_replace_callback( '/<(script|style|svg|math).*?<\/\\1>/s', [(new self), '_autop_newline_preservation_helper'], $text );
+
+            // Normalize <br>
+            $text = str_replace( array( '<br>', '<br/>' ), '<br />', $text );
+
+            // Replace any new line characters that aren't preceded by a <br /> with a <br />.
+            $text = preg_replace( '|(?<!<br />)\s*\n|', "<br />\n", $text );
+
+            // Replace newline placeholders with newlines.
+            $text = str_replace( '<WPPreserveNewline />', "\n", $text );
+        }
+
+        // If a <br /> tag is after an opening or closing block tag, remove it.
+        $text = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*<br />!', '$1', $text );
+
+        // If a <br /> tag is before a subset of opening or closing block tags, remove it.
+        $text = preg_replace( '!<br />(\s*</?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)[^>]*>)!', '$1', $text );
+        $text = preg_replace( "|\n</p>$|", '</p>', $text );
+
+        // Replace placeholder <pre> tags with their original content.
+        if ( ! empty( $pre_tags ) ) {
+            $text = str_replace( array_keys( $pre_tags ), array_values( $pre_tags ), $text );
+        }
+
+        // Restore newlines in all elements.
+        if ( str_contains( $text, '<!-- wpnl -->' ) ) {
+            $text = str_replace( array( ' <!-- wpnl --> ', '<!-- wpnl -->' ), "\n", $text );
+        }
+
+        return $text;
+    }
+
+    /**
+     * Replaces characters or phrases within HTML elements only.
+     *
+     * @since 4.2.3
+     *
+     * @param string $haystack      The text which has to be formatted.
+     * @param array  $replace_pairs In the form array('from' => 'to', ...).
+     * @return string The formatted text.
+     */
+    private static function wp_replace_in_html_tags( $haystack, $replace_pairs ) {
+        // Find all elements.
+        $textarr = static::wp_html_split( $haystack );
+        $changed = false;
+
+        // Optimize when searching for one item.
+        if ( 1 === count( $replace_pairs ) ) {
+            // Extract $needle and $replace.
+            $needle  = array_key_first( $replace_pairs );
+            $replace = $replace_pairs[ $needle ];
+
+            // Loop through delimiters (elements) only.
+            for ( $i = 1, $c = count( $textarr ); $i < $c; $i += 2 ) {
+                if ( str_contains( $textarr[ $i ], $needle ) ) {
+                    $textarr[ $i ] = str_replace( $needle, $replace, $textarr[ $i ] );
+                    $changed       = true;
+                }
+            }
+        } else {
+            // Extract all $needles.
+            $needles = array_keys( $replace_pairs );
+
+            // Loop through delimiters (elements) only.
+            for ( $i = 1, $c = count( $textarr ); $i < $c; $i += 2 ) {
+                foreach ( $needles as $needle ) {
+                    if ( str_contains( $textarr[ $i ], $needle ) ) {
+                        $textarr[ $i ] = strtr( $textarr[ $i ], $replace_pairs );
+                        $changed       = true;
+                        // After one strtr() break out of the foreach loop and look at next element.
+                        break;
+                    }
+                }
+            }
+        }
+
+        if ( $changed ) {
+            $haystack = implode( $textarr );
+        }
+
+        return $haystack;
+    }
+
+    /**
+     * Separates HTML elements and comments from the text.
+     *
+     * @since 4.2.4
+     *
+     * @param string $input The text which has to be formatted.
+     * @return string[] Array of the formatted text.
+     */
+    private static function wp_html_split( $input )
+    {
+        return preg_split( static::get_html_split_regex(), $input, -1, PREG_SPLIT_DELIM_CAPTURE );
+    }
+
+    /**
+     * Retrieves the regular expression for an HTML element.
+     *
+     * @since 4.4.0
+     *
+     * @return string The regular expression
+     */
+    private static function get_html_split_regex() {
+        static $regex;
+
+        if ( ! isset( $regex ) ) {
+            // phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- don't remove regex indentation
+            $comments =
+                '!'             // Start of comment, after the <.
+                . '(?:'         // Unroll the loop: Consume everything until --> is found.
+                .     '-(?!->)' // Dash not followed by end of comment.
+                .     '[^\-]*+' // Consume non-dashes.
+                . ')*+'         // Loop possessively.
+                . '(?:-->)?';   // End of comment. If not found, match all input.
+
+            $cdata =
+                '!\[CDATA\['    // Start of comment, after the <.
+                . '[^\]]*+'     // Consume non-].
+                . '(?:'         // Unroll the loop: Consume everything until ]]> is found.
+                .     '](?!]>)' // One ] not followed by end of comment.
+                .     '[^\]]*+' // Consume non-].
+                . ')*+'         // Loop possessively.
+                . '(?:]]>)?';   // End of comment. If not found, match all input.
+
+            $escaped =
+                '(?='             // Is the element escaped?
+                .    '!--'
+                . '|'
+                .    '!\[CDATA\['
+                . ')'
+                . '(?(?=!-)'      // If yes, which type?
+                .     $comments
+                . '|'
+                .     $cdata
+                . ')';
+
+            $regex =
+                '/('                // Capture the entire match.
+                .     '<'           // Find start of element.
+                .     '(?'          // Conditional expression follows.
+                .         $escaped  // Find end of escaped element.
+                .     '|'           // ...else...
+                .         '[^>]*>?' // Find end of normal element.
+                .     ')'
+                . ')/';
+            // phpcs:enable
+        }
+
+        return $regex;
+    }
+
+    /**
+     * Newline preservation help function for wpautop().
+     *
+     * @since 3.1.0
+     * @access private
+     *
+     * @param array $matches preg_replace_callback matches array
+     * @return string
+     */
+    private function _autop_newline_preservation_helper( $matches )
+    {
+        return str_replace( "\n", '<WPPreserveNewline />', $matches[0] );
+    }
+}

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -159,7 +159,7 @@ class BardTransformer extends AbstractTransformer
         $fieldItems = [
             'wp_auto_p' => [
                 'type' => 'toggle',
-                'display' => __('WordPress: Run "wpautop"?'),
+                'display' => __('WordPress: Replace double line-breaks with <p> tags'),
                 'instructions' => __('importer::messages.bard_wp_auto_p_instructions'),
             ],
         ];

--- a/tests/Transformers/BardTransformerTest.php
+++ b/tests/Transformers/BardTransformerTest.php
@@ -84,6 +84,68 @@ HTML);
     }
 
     #[Test]
+    public function it_passes_value_through_wpautop()
+    {
+        $transformer = new BardTransformer(
+            import: $this->import,
+            blueprint: $this->blueprint,
+            field: $this->field,
+            config: [
+                'wp_auto_p' => true,
+            ]
+        );
+
+        $output = $transformer->transform(<<<'HTML'
+<strong>Foo <a href="https://example.com">Bar</a> Baz.</strong>
+<h2>Heading</h2>
+One. Two. Three. Four.
+
+<img src="/images/pizza.jpg" alt="Picture of pizza" width="100" height="100" />
+
+Ein.
+Zwei.
+
+Drei.
+
+<a class="btn btn-primary" href="https://statamic.com">Statamic</a>
+<h2>Heading 2</h2>
+Blah. <a href="https://example.com">Link</a> blah.
+HTML);
+
+        $this->assertEquals([
+            ['type' => 'paragraph', 'attrs' => ['textAlign' => 'left'], 'content' => [
+                ['type' => 'text', 'text' => 'Foo ', 'marks' => [['type' => 'bold']]],
+                ['type' => 'text', 'text' => 'Bar', 'marks' => [['type' => 'bold'], ['type' => 'link', 'attrs' => ['href' => 'https://example.com']]]],
+                ['type' => 'text', 'text' => ' Baz.', 'marks' => [['type' => 'bold']]],
+            ]],
+            ['type' => 'heading', 'attrs' => ['level' => 2, 'textAlign' => 'left'], 'content' => [['type' => 'text', 'text' => 'Heading']]],
+            ['type' => 'paragraph', 'attrs' => ['textAlign' => 'left'], 'content' => [
+                ['type' => 'text', 'text' => 'One. Two. Three. Four.'],
+            ]],
+            ['type' => 'paragraph', 'attrs' => ['textAlign' => 'left'], 'content' => [
+                ['type' => 'image', 'attrs' => ['src' => '/images/pizza.jpg']],
+            ]],
+            ['type' => 'paragraph', 'attrs' => ['textAlign' => 'left'], 'content' => [
+               ['type' => 'text', 'text' => 'Ein.'],
+               ['type' => 'hardBreak'],
+                ['type' => 'text', 'text' => 'Zwei.'],
+            ]],
+            ['type' => 'paragraph', 'attrs' => ['textAlign' => 'left'], 'content' => [
+                ['type' => 'text', 'text' => 'Drei.'],
+            ]],
+            ['type' => 'paragraph', 'attrs' => ['textAlign' => 'left'], 'content' => [
+                ['type' => 'text', 'text' => 'Statamic', 'marks' => [['type' => 'link', 'attrs' => ['href' => 'https://statamic.com']]]],
+            ]],
+            ['type' => 'heading', 'attrs' => ['level' => 2, 'textAlign' => 'left'], 'content' => [['type' => 'text', 'text' => 'Heading 2']]],
+            ['type' => 'paragraph', 'attrs' => ['textAlign' => 'left'], 'content' => [
+                ['type' => 'text', 'text' => 'Blah. '],
+                ['type' => 'text', 'text' => 'Link', 'marks' => [['type' => 'link', 'attrs' => ['href' => 'https://example.com']]]],
+                ['type' => 'text', 'text' => ' blah.'],
+            ]],
+        ], $output);
+    }
+
+    #[Test]
     public function it_handles_images()
     {
         AssetContainer::make('assets')->disk('public')->save();


### PR DESCRIPTION
This pull request attempts to fix text formatting issues for conent imported from WordPress' Classic Editor. 

It doesn't seem like the Classic Editor saves `<p>` tags when a post's content are saved in the database. Here's an example: 

```html
Non ad deserunt ea consectetur elit eu eiusmod commodo culpa ex labore incididunt culpa veniam voluptate. U<strong>llamco est excepteur laborum pariatur non aliqua qui eu labore sunt. Laborum elit dolore laboris eu enim ut. Ullamco exercitation et reprehenderit elit eiusmod officia pariatur ipsum elit. Consectetur veniam irure nostrud nisi eiusmod est Lorem voluptate aute officia occaecat eu. Cillum deserunt consequat fugiat sint velit. Quis magna elit incididunt excepteur do laboris. Ullamco laborum d</strong>olore Lorem fugiat cillum consectetur dolore laborum dolor aute culpa consequat proident.
<h2>Testing</h2>
Veniam nulla cillum esse dolor et eiusmod eu pariatur et ex qui dolore consequat occaecat amet. Exercitation occaecat ea sit id amet cupidatat sint veniam mollit velit sunt culpa. Do esse aliquip elit aute. Duis consectetur consectetur minim exercitation quis do enim consectetur quis laboris cillum ex c<a href="https://statamic.com">ulpa eu. Ipsum consequat commodo reprehenderit velit aliqua officia commodo voluptate Lorem duis cillum culpa incididunt ea laboris. Sunt veniam ipsum minim cupidatat. Labore cillum voluptate voluptate</a> mollit ad. Sit nulla ea esse mollit excepteur et voluptate cupidatat reprehenderit velit non minim Lorem.
```

However, when content is displayed on the frontend, it gets passed through WordPress' [`wpautop`](https://developer.wordpress.org/reference/functions/wpautop/) function which essentially runs the content through various regexes before outputting HTML to the browser.

However, since the content doesn't get passed through `wpautop` during an export, we end up with the unnormalized "string" which breaks TipTap (the library behind Bard).

In order to workaround this, we've added a config option which'll run your content through `wpautop` *before* transforming it into the right format for Bard. 

Fixes #62.
Replaces #65.