### PR TITLE
Add fallback values for job batches database config

### DIFF
--- a/src/Http/Controllers/ImportController.php
+++ b/src/Http/Controllers/ImportController.php
@@ -217,7 +217,7 @@ class ImportController extends CpController
     private function ensureJobBatchesTableExists(): bool
     {
         try {
-            if (Schema::connection(config('queue.batching.database'))->hasTable(config('queue.batching.table'))) {
+            if (Schema::connection(config('queue.batching.database', env('DB_CONNECTION', 'sqlite')))->hasTable(config('queue.batching.table', 'job_batches'))) {
                 return true;
             }
         } catch (QueryException $e) {

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -21,7 +21,7 @@ class Importer
     {
         Cache::forget("importer.{$import->id}.parents");
 
-        if (! Schema::connection(config('queue.batching.database'))->hasTable(config('queue.batching.table'))) {
+        if (! Schema::connection(config('queue.batching.database', env('DB_CONNECTION', 'sqlite')))->hasTable(config('queue.batching.table', 'job_batches'))) {
             throw new JobBatchesTableMissingException;
         }
 


### PR DESCRIPTION
This pull request adds fallbacks values to where we're getting the `job_batches` database config, to prevent issues when the `batching` array isn't present in the app's `queue` config file.

Fixes #90.