### PR TITLE
Fix flakey tests

### DIFF
--- a/tests/Imports/StoreImportTest.php
+++ b/tests/Imports/StoreImportTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\User;
+use Statamic\Http\Middleware\DeleteTemporaryFileUploads;
 use Statamic\Importer\Facades\Import;
 use Statamic\Importer\Tests\TestCase;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -19,6 +20,8 @@ class StoreImportTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->withoutMiddleware(DeleteTemporaryFileUploads::class);
 
         File::deleteDirectory(storage_path('statamic/importer'));
         Storage::disk('local')->deleteDirectory('statamic/file-uploads');

--- a/tests/Imports/UpdateImportTest.php
+++ b/tests/Imports/UpdateImportTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\User;
+use Statamic\Http\Middleware\DeleteTemporaryFileUploads;
 use Statamic\Importer\Facades\Import;
 use Statamic\Importer\Tests\TestCase;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -21,6 +22,8 @@ class UpdateImportTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->withoutMiddleware(DeleteTemporaryFileUploads::class);
 
         File::deleteDirectory(storage_path('statamic/importer'));
 


### PR DESCRIPTION
Almost every time I run the test suite on GitHub Actions, one of the tests in `StoreImportTest` or `UpdateImportTest` have failed causing me to retry the jobs to get them to pass.

After months of not being able to figure it out, I finally realised I probably need to ignore Statamic's `DeleteTemporaryFileUploads` middleware in those tests as it's responsible for randomly deleting file uploads. 🫠