### PR TITLE
Fix field value of "0" not being imported

### DIFF
--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -36,7 +36,7 @@ class ImportItemJob implements ShouldQueue
                 $field = $fields->get($fieldHandle);
                 $value = Arr::get($this->item, $mapping['key']);
 
-                if (! $value) {
+                if (is_null($value) || $value === '') {
                     return [$fieldHandle => null];
                 }
 


### PR DESCRIPTION
This pull request fixes an issue when importing "0" as the value for a field, by making the "is empty value" check more explicit.

