### PR TITLE
Fix: SQLite "too many SQL variables" error in Importer

### DIFF
--- a/src/Importer.php
+++ b/src/Importer.php
@@ -30,14 +30,18 @@ class Importer
             'xml' => (new Xml($import))->getItems($import->get('path')),
         };
 
-        Bus::batch($items->map(fn (array $item) => new ImportItemJob($import, $item)))
-            ->before(fn (Batch $batch) => $import->batchId($batch->id)->save())
+        $chunks = $items->chunk(500);
+
+        foreach ($chunks as $chunk) {
+            Bus::batch($chunk->map(fn (array $item) => new ImportItemJob($import, $item)))
+                ->before(fn (Batch $batch) => $import->batchId($batch->id)->save())
             ->finally(function (Batch $batch) use ($import) {
                 if ($import->get('destination.type') === 'entries') {
                     UpdateCollectionTreeJob::dispatch($import);
                 }
             })
             ->dispatch();
+        }
     }
 
     public static function getTransformer(string $fieldtype): ?string


### PR DESCRIPTION
When importing large datasets with SQLite, the process fails with too many SQL variables error because SQLite has a variable limit in queries.

This PR chunks the items into smaller batches.

Tested with 5,000+ row XML import - successfully processes without errors.

Fixes #96 