### PR TITLE
Refactor XML item parsing in Xml source to use XMLReader

### DIFF
--- a/src/Sources/Xml.php
+++ b/src/Sources/Xml.php
@@ -8,35 +8,45 @@ class Xml extends AbstractSource
 {
     public function getItems(string $path): LazyCollection
     {
-        $xml = simplexml_load_file($path);
+        return LazyCollection::make(function () use ($path) {
+            $reader = new \XMLReader;
+            $reader->open($path);
 
-        return LazyCollection::make(function () use ($xml) {
-            foreach ($xml->channel->item as $item) {
-                $array = [];
+            while ($reader->read()) {
+                if ($reader->nodeType === \XMLReader::ELEMENT && $reader->name === 'item') {
+                    $node = $reader->expand();
+                    $array = [];
 
-                foreach ($item as $key => $value) {
-                    $array[$key] = (string) $value;
-                }
+                    $doc = new \DOMDocument;
+                    $node = $doc->importNode($node, true);
+                    $doc->appendChild($node);
+                    $item = simplexml_import_dom($doc);
 
-                foreach ($item->getDocNamespaces(true) as $namespace => $uri) {
-                    // Access namespaced elements using the namespace prefix
-                    foreach ($item->children($uri) as $key => $value) {
-                        $array[$namespace.':'.$key] = (string) $value;
+                    foreach ($item as $key => $value) {
+                        $array[$key] = (string) $value;
                     }
 
-                    // If you want to access attributes in the namespaced elements
-                    foreach ($item->attributes($uri) as $key => $value) {
-                        $array[$namespace.':'.$key] = (string) $value;
+                    foreach ($item->getDocNamespaces(true) as $namespace => $uri) {
+                        // Access namespaced elements using the namespace prefix
+                        foreach ($item->children($uri) as $key => $value) {
+                            $array[$namespace.':'.$key] = (string) $value;
+                        }
+
+                        // If you want to access attributes in the namespaced elements
+                        foreach ($item->attributes($uri) as $key => $value) {
+                            $array[$namespace.':'.$key] = (string) $value;
+                        }
                     }
-                }
 
-                // WordPress: Filter out any `attachment` post types.
-                if (isset($array['wp:post_type']) && $array['wp:post_type'] === 'attachment') {
-                    continue;
-                }
+                    if (isset($array['wp:post_type']) && $array['wp:post_type'] === 'attachment') {
+                        continue;
+                    }
 
-                yield $array;
+                    yield $array;
+                }
             }
+
+            $reader->close();
         });
     }
 }


### PR DESCRIPTION
# Optimize XML Processing with XMLReader

Replaces `simplexml_load_file` with `XMLReader` for more memory-efficient XML processing. This change allows the importer to process XML files in a streaming fashion instead of loading the entire file into memory at once.

The functionality remains the same, but the implementation is now more scalable for large XML files.