### PR TITLE
Toggle should default to false when value isn't configured

### DIFF
--- a/src/Transformers/ToggleTransformer.php
+++ b/src/Transformers/ToggleTransformer.php
@@ -19,6 +19,7 @@ class ToggleTransformer extends AbstractTransformer
             return match (true) {
                 in_array($value, explode('|', $this->config('values.true'))) => true,
                 in_array($value, explode('|', $this->config('values.false'))) => false,
+                default => false,
             };
         }
     }

--- a/tests/Transformers/ToggleTransformerTest.php
+++ b/tests/Transformers/ToggleTransformerTest.php
@@ -61,5 +61,6 @@ class ToggleTransformerTest extends TestCase
         $this->assertTrue($transformer->transform('yep'));
 
         $this->assertFalse($transformer->transform('no'));
+        $this->assertFalse($transformer->transform('nope'));  // Not configured, should default to false
     }
 }


### PR DESCRIPTION
This pull request prevents an error when importing a toggle field, when the imported value doesn't match one of the configured true/false values.

Instead of erroring, the toggle will now default to `false`. 