### PR TITLE
Fix error when importing Gutenberg's `core/embed` block

### DIFF
--- a/src/WordPress/Gutenberg.php
+++ b/src/WordPress/Gutenberg.php
@@ -217,7 +217,7 @@ class Gutenberg
                 }
 
                 if ($block['blockName'] === 'core/embed') {
-                    if (in_array($block['attrs']['providerNameSlug'], ['youtube', 'vimeo'])) {
+                    if (isset($block['attrs']['providerNameSlug']) && in_array($block['attrs']['providerNameSlug'], ['youtube', 'vimeo'])) {
                         static::ensureBardSet($blueprint, $field, 'video', [
                             'display' => __('Video'),
                             'icon' => 'media-webcam-video',


### PR DESCRIPTION
This pull request fixes an error with the `core/embed` block, where the `providerNameSlug` key isn't always set.
