### PR TITLE
Fix undefined array key error from `FieldUpdater`

### DIFF
--- a/src/Support/FieldUpdater.php
+++ b/src/Support/FieldUpdater.php
@@ -53,7 +53,7 @@ class FieldUpdater
     {
         return $this->blueprint->fields()->items()
             ->where('handle', $this->field->handle())
-            ->filter(fn(array $field) => isset($field['field']) && is_string($field['field']))
+            ->filter(fn (array $field) => isset($field['field']) && is_string($field['field']))
             ->first();
     }
 
@@ -93,13 +93,11 @@ class FieldUpdater
 
     /**
      * Determines if a field is imported from a fieldset by checking if it exists in the blueprint's top-level fields.
-     *
-     * @return bool
      */
     private function isImportedField(): bool
     {
         $topLevelFieldHandles = $this->blueprint->tabs()
-            ->flatMap(fn($tab) => $tab->sections()->flatMap(fn($section) => $section->fields()->items()))
+            ->flatMap(fn ($tab) => $tab->sections()->flatMap(fn ($section) => $section->fields()->items()))
             ->pluck('handle')
             ->filter();
 
@@ -117,8 +115,8 @@ class FieldUpdater
     {
         /** @var \Statamic\Fields\Fieldset $fieldset */
         $fieldset = $this->blueprint->fields()->items()
-            ->filter(fn(array $field) => isset($field['import']))
-            ->map(fn(array $field) => Fieldset::find($field['import']))
+            ->filter(fn (array $field) => isset($field['import']))
+            ->map(fn (array $field) => Fieldset::find($field['import']))
             ->filter(function ($fieldset) use ($prefix) {
                 return collect($fieldset->fields()->items())
                     ->where('handle', Str::after($this->field->handle(), $prefix ?? ''))

--- a/src/Support/FieldUpdater.php
+++ b/src/Support/FieldUpdater.php
@@ -29,14 +29,14 @@ class FieldUpdater
 
     public function updateFieldConfig(array $config): void
     {
-        if ($prefix = $this->field->prefix()) {
-            $this->updatePrefixedField($prefix, $config);
+        if ($linkedField = $this->getLinkedField()) {
+            $this->updateLinkedField($linkedField, $config);
 
             return;
         }
 
-        if ($importedField = $this->getImportedField()) {
-            $this->updateImportedField($importedField, $config);
+        if ($this->isImportedField()) {
+            $this->updateImportedField($config, $this->field->prefix());
 
             return;
         }
@@ -49,22 +49,22 @@ class FieldUpdater
         $this->blueprint->save();
     }
 
-    private function getImportedField(): ?array
+    private function getLinkedField(): ?array
     {
         return $this->blueprint->fields()->items()
             ->where('handle', $this->field->handle())
-            ->filter(fn (array $field) => isset($field['field']) && is_string($field['field']))
+            ->filter(fn(array $field) => isset($field['field']) && is_string($field['field']))
             ->first();
     }
 
     /**
-     * This method handles updating imported fields from fieldsets.
+     * This method handles updating linked fields from fieldsets.
      *
      * -
      *   handle: foo
      *   field: fieldset.foo
      */
-    private function updateImportedField(array $importedField, array $config): void
+    private function updateLinkedField(array $importedField, array $config): void
     {
         /** @var \Statamic\Fields\Fieldset $fieldset */
         $fieldHandle = Str::after($importedField['field'], '.');
@@ -92,21 +92,36 @@ class FieldUpdater
     }
 
     /**
-     * This method handles updating imported fields from fieldsets, which use a prefix.
+     * Determines if a field is imported from a fieldset by checking if it exists in the blueprint's top-level fields.
+     *
+     * @return bool
+     */
+    private function isImportedField(): bool
+    {
+        $topLevelFieldHandles = $this->blueprint->tabs()
+            ->flatMap(fn($tab) => $tab->sections()->flatMap(fn($section) => $section->fields()->items()))
+            ->pluck('handle')
+            ->filter();
+
+        return $this->blueprint->hasField($this->field->handle()) && ! $topLevelFieldHandles->contains($this->field->handle());
+    }
+
+    /**
+     * This method handles updating imported fields from fieldsets, either with or without prefixes.
      *
      * -
      *   import: fieldset
      *   prefix: foo_
      */
-    private function updatePrefixedField(string $prefix, array $config): void
+    private function updateImportedField(array $config, ?string $prefix = null): void
     {
         /** @var \Statamic\Fields\Fieldset $fieldset */
         $fieldset = $this->blueprint->fields()->items()
-            ->filter(fn (array $field) => isset($field['import']))
-            ->map(fn (array $field) => Fieldset::find($field['import']))
+            ->filter(fn(array $field) => isset($field['import']))
+            ->map(fn(array $field) => Fieldset::find($field['import']))
             ->filter(function ($fieldset) use ($prefix) {
                 return collect($fieldset->fields()->items())
-                    ->where('handle', Str::after($this->field->handle(), $prefix))
+                    ->where('handle', Str::after($this->field->handle(), $prefix ?? ''))
                     ->isNotEmpty();
             })
             ->first();
@@ -115,7 +130,7 @@ class FieldUpdater
             ...$fieldset->contents(),
             'fields' => collect($fieldset->contents()['fields'])
                 ->map(function (array $field) use ($config, $prefix) {
-                    if ($field['handle'] === Str::after($this->field->handle(), $prefix)) {
+                    if ($field['handle'] === Str::after($this->field->handle(), $prefix ?? '')) {
                         return [
                             'handle' => $field['handle'],
                             'field' => $config,

--- a/tests/Transformers/BardTransformerTest.php
+++ b/tests/Transformers/BardTransformerTest.php
@@ -422,6 +422,44 @@ HTML);
     }
 
     #[Test]
+    public function it_enables_buttons_on_imported_bard_field_without_prefix()
+    {
+        Fieldset::make('content_stuff')->setContents(['fields' => [
+            ['handle' => 'bard_field', 'field' => ['type' => 'bard']],
+        ]])->save();
+
+        $blueprint = $this->collection->entryBlueprint();
+
+        $this->blueprint->setContents([
+            'sections' => [
+                'main' => [
+                    'fields' => [
+                        ['import' => 'content_stuff'],
+                    ],
+                ],
+            ],
+        ])->save();
+
+        $transformer = new BardTransformer(
+            import: $this->import,
+            blueprint: $blueprint,
+            field: $blueprint->field('bard_field'),
+            config: []
+        );
+
+        $transformer->transform('<h2 style="text-align: center;"><strong>Hello</strong> <em>world</em>!</h2>');
+
+        $fieldset = Fieldset::find('content_stuff');
+
+        $this->assertEquals([
+            'h2',
+            'aligncenter',
+            'bold',
+            'italic',
+        ], $fieldset->field('bard_field')->get('buttons'));
+    }
+
+    #[Test]
     public function it_enables_buttons_on_imported_bard_field_with_prefix()
     {
         Fieldset::make('content_stuff')->setContents(['fields' => [

--- a/tests/Transformers/BardTransformerTest.php
+++ b/tests/Transformers/BardTransformerTest.php
@@ -384,7 +384,7 @@ HTML);
     }
 
     #[Test]
-    public function it_enables_buttons_on_imported_bard_field()
+    public function it_enables_buttons_on_linked_bard_field()
     {
         Fieldset::make('content_stuff')->setContents(['fields' => [
             ['handle' => 'bard_field', 'field' => ['type' => 'bard']],
@@ -422,7 +422,7 @@ HTML);
     }
 
     #[Test]
-    public function it_enables_buttons_on_imported_bard_field_without_prefix()
+    public function it_enables_buttons_on_imported_bard_field()
     {
         Fieldset::make('content_stuff')->setContents(['fields' => [
             ['handle' => 'bard_field', 'field' => ['type' => 'bard']],


### PR DESCRIPTION
This pull request fixes an issue with the `FieldUpdater` (used to update Bard configs) to handle the situation where an imported field doesn't have a prefix.

Fixes #106.