### PR TITLE
Fix importing bard assets

### DIFF
--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -71,7 +71,7 @@ class BardTransformer extends AbstractTransformer
                 return null;
             }
 
-            $node['attrs']['src'] = $asset->id();
+            $node['attrs']['src'] = 'asset::'.$asset->id();
         }
 
         if (isset($node['content'])) {

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -60,7 +60,12 @@ class BardTransformer extends AbstractTransformer
                 ]
             );
 
-            $asset = $assetContainer->asset(path: $transformer->transform($node['attrs']['src']));
+            $path = $transformer->transform($node['attrs']['src']);
+            if (! $path) {
+                return null;
+            }
+
+            $asset = $assetContainer->asset(path: $path);
 
             if (! $asset) {
                 return null;

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -61,6 +61,7 @@ class BardTransformer extends AbstractTransformer
             );
 
             $path = $transformer->transform($node['attrs']['src']);
+
             if (! $path) {
                 return null;
             }

--- a/tests/Transformers/BardTransformerTest.php
+++ b/tests/Transformers/BardTransformerTest.php
@@ -178,7 +178,7 @@ HTML);
             [
                 'type' => 'image',
                 'attrs' => [
-                    'src' => 'assets::2024/10/image.png',
+                    'src' => 'asset::assets::2024/10/image.png',
                 ],
             ],
         ], $output);
@@ -221,7 +221,7 @@ HTML);
                     [
                         'type' => 'image',
                         'attrs' => [
-                            'src' => 'assets::2024/10/image.png',
+                            'src' => 'asset::assets::2024/10/image.png',
                         ],
                     ],
                 ],
@@ -305,7 +305,7 @@ HTML);
             [
                 'type' => 'image',
                 'attrs' => [
-                    'src' => 'assets::2024/10/image.png',
+                    'src' => 'asset::assets::2024/10/image.png',
                 ],
             ],
         ], $output);
@@ -353,7 +353,7 @@ HTML);
             [
                 'type' => 'image',
                 'attrs' => [
-                    'src' => 'assets::custom-folder/image.png',
+                    'src' => 'asset::assets::custom-folder/image.png',
                 ],
             ],
         ], $output);


### PR DESCRIPTION
The `AssetsTransformer` will return `null` if URL based assets fail to download, but there's no check for this before creating the asset object, resulting in an `Undefined array key "dirname"` error when the asset's folder method is called.

This PR fixes it by checking a path is returned first.

The node `src` values are also missing the `asset::` prefix, which prevents them from augmenting correctly on the frontend. This PR also adds that.