### PR TITLE
Fix error when importing file dictionary field

### DIFF
--- a/src/Transformers/DictionaryTransformer.php
+++ b/src/Transformers/DictionaryTransformer.php
@@ -30,6 +30,6 @@ class DictionaryTransformer extends AbstractTransformer
             return Facades\Dictionary::find($dictionary);
         }
 
-        return Facades\Dictionary::find($dictionary['type']);
+        return Facades\Dictionary::find($dictionary['type'], $dictionary);
     }
 }


### PR DESCRIPTION
This pull request fixes an issue when importing [file dictionary](https://statamic.dev/fieldtypes/dictionary#file) fields (or any other dictionary which relies on its config options).

Fixes #110.