### PR TITLE
Fix issue where missing key might break import

### DIFF
--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -58,16 +58,17 @@ class ImportItemJob implements ShouldQueue
 
     protected function findOrCreateEntry(array $data): void
     {
+        $entry = null;
         $collection = Collection::find($this->import->get('destination.collection'));
         $site = Site::get($this->import->get('destination.site') ?? Site::default()->handle());
 
-        $entry = isset($data[$this->import->get('unique_field')])
-            ? Entry::query()
+        if ($uniqueFieldValue = Arr::get($data, $this->import->get('unique_field'))) {
+            $entry = Entry::query()
                 ->where('site', $site->handle())
                 ->where('collection', $collection->handle())
-                ->where($this->import->get('unique_field'), $data[$this->import->get('unique_field')])
-                ->first()
-            : null;
+                ->where($this->import->get('unique_field'), $uniqueFieldValue)
+                ->first();
+        }
 
         if (! $entry) {
             if (! in_array('create', $this->import->get('strategy'))) {

--- a/src/Jobs/ImportItemJob.php
+++ b/src/Jobs/ImportItemJob.php
@@ -61,11 +61,13 @@ class ImportItemJob implements ShouldQueue
         $collection = Collection::find($this->import->get('destination.collection'));
         $site = Site::get($this->import->get('destination.site') ?? Site::default()->handle());
 
-        $entry = Entry::query()
-            ->where('site', $site->handle())
-            ->where('collection', $collection->handle())
-            ->where($this->import->get('unique_field'), $data[$this->import->get('unique_field')])
-            ->first();
+        $entry = isset($data[$this->import->get('unique_field')])
+            ? Entry::query()
+                ->where('site', $site->handle())
+                ->where('collection', $collection->handle())
+                ->where($this->import->get('unique_field'), $data[$this->import->get('unique_field')])
+                ->first()
+            : null;
 
         if (! $entry) {
             if (! in_array('create', $this->import->get('strategy'))) {


### PR DESCRIPTION
Hi!

While trying to import contents from a WordPress site I ran into this issue where if you tried to use the Slug as the unique field it would break since the "slug" key was missing on "drafts" and other non-published posts.