### PR TITLE
[2.x] Remove string typehint from `Transformer::transform()` method

### DIFF
--- a/src/Contracts/Transformer.php
+++ b/src/Contracts/Transformer.php
@@ -4,5 +4,5 @@ namespace Statamic\Importer\Contracts;
 
 interface Transformer
 {
-    public function transform(string $value);
+    public function transform($value);
 }

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -21,7 +21,7 @@ abstract class AbstractTransformer implements Transformer
         protected ?array $values = null,
     ) {}
 
-    abstract public function transform(string $value);
+    abstract public function transform($value);
 
     public function fieldItems(): array
     {

--- a/src/Transformers/AssetsTransformer.php
+++ b/src/Transformers/AssetsTransformer.php
@@ -20,7 +20,7 @@ use Statamic\Support\Str;
 
 class AssetsTransformer extends AbstractTransformer
 {
-    public function transform(string $value): null|string|array
+    public function transform($value): null|string|array
     {
         $assetContainer = $this->field->get('container')
             ? AssetContainer::find($this->field->get('container'))

--- a/src/Transformers/BardTransformer.php
+++ b/src/Transformers/BardTransformer.php
@@ -13,7 +13,7 @@ use Statamic\Support\Str;
 
 class BardTransformer extends AbstractTransformer
 {
-    public function transform(string $value): array
+    public function transform($value): array
     {
         if ($this->isGutenbergValue($value)) {
             $value = Gutenberg::toBard(

--- a/src/Transformers/DateTransformer.php
+++ b/src/Transformers/DateTransformer.php
@@ -11,7 +11,7 @@ use Statamic\Support\Str;
 
 class DateTransformer extends AbstractTransformer
 {
-    public function transform(string $value): array|int|string
+    public function transform($value): array|int|string
     {
         if ($this->field->get('mode') === 'range') {
             return [

--- a/src/Transformers/DictionaryTransformer.php
+++ b/src/Transformers/DictionaryTransformer.php
@@ -8,7 +8,7 @@ use Statamic\Support\Str;
 
 class DictionaryTransformer extends AbstractTransformer
 {
-    public function transform(string $value): null|string|array
+    public function transform($value): null|string|array
     {
         // When $value is a JSON string, decode it.
         if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {

--- a/src/Transformers/EntriesTransformer.php
+++ b/src/Transformers/EntriesTransformer.php
@@ -10,7 +10,7 @@ use Statamic\Support\Str;
 
 class EntriesTransformer extends AbstractTransformer
 {
-    public function transform(string $value): null|string|array
+    public function transform($value): null|string|array
     {
         // When $value is a serialized array, deserialize it.
         if (Str::startsWith($value, 'a:')) {

--- a/src/Transformers/ListTransformer.php
+++ b/src/Transformers/ListTransformer.php
@@ -6,7 +6,7 @@ use Statamic\Support\Str;
 
 class ListTransformer extends AbstractTransformer
 {
-    public function transform(string $value)
+    public function transform($value)
     {
         // When $value is a serialized array, deserialize it.
         if (Str::startsWith($value, 'a:')) {

--- a/src/Transformers/TermsTransformer.php
+++ b/src/Transformers/TermsTransformer.php
@@ -9,7 +9,7 @@ use Statamic\Support\Str;
 
 class TermsTransformer extends AbstractTransformer
 {
-    public function transform(string $value): null|string|array
+    public function transform($value): null|string|array
     {
         // When $value is a JSON string, decode it.
         if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {

--- a/src/Transformers/ToggleTransformer.php
+++ b/src/Transformers/ToggleTransformer.php
@@ -6,7 +6,7 @@ use Statamic\Statamic;
 
 class ToggleTransformer extends AbstractTransformer
 {
-    public function transform(string $value): bool
+    public function transform($value): bool
     {
         if ($this->config('format') === 'boolean') {
             return match ($value) {

--- a/src/Transformers/UsersTransformer.php
+++ b/src/Transformers/UsersTransformer.php
@@ -7,7 +7,7 @@ use Statamic\Support\Str;
 
 class UsersTransformer extends AbstractTransformer
 {
-    public function transform(string $value): null|string|array
+    public function transform($value): null|string|array
     {
         // When $value is a JSON string, decode it.
         if (Str::startsWith($value, ['{', '[']) || Str::startsWith($value, ['[', ']'])) {


### PR DESCRIPTION
This pull request removes the string typehint from the `Transformer::transform()` method. 

If and when we add JSON support, we'll need to be able to pass arrays and integers to transformers (eg. an array of related entry IDs).

As it's a breaking change, I wanted to get this into 2.x so JSON Support doesn't need to happen alongside a major release.