### PR TITLE
Support symfony/css-selector 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "spatie/simple-excel": "^3.7",
         "symfony/dom-crawler": "^7.1",
         "pixelfear/composer-dist-plugin": "^0.1.5",
-        "symfony/css-selector": "^7.1"
+        "symfony/css-selector": "^7.1 || ^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",


### PR DESCRIPTION
Currently, when you try to install this addon in a fresh Statamic site, you'll get this error from Composer:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires statamic/importer * -> satisfiable by statamic/importer[v1.0.0, ..., v1.9.0, v2.0.0].
    - statamic/importer[v1.0.0, ..., v1.0.2] require statamic/cms ^5.35.0 -> found statamic/cms[v5.35.0, ..., v5.73.7] but it conflicts with your root composer.json require (^6.0).
    - statamic/importer[v1.1.0, ..., v1.2.0] require statamic/cms ^5.0 -> found statamic/cms[v5.0.0, ..., v5.73.7] but it conflicts with your root composer.json require (^6.0).
    - statamic/importer[v1.3.0, ..., v1.4.1] require statamic/cms ^5.38 -> found statamic/cms[v5.38.0, ..., v5.73.7] but it conflicts with your root composer.json require (^6.0).
    - statamic/importer[v1.5.0, ..., v1.9.0] require statamic/cms ^5.41 -> found statamic/cms[v5.41.0, ..., v5.73.7] but it conflicts with your root composer.json require (^6.0).
    - statamic/importer v2.0.0 requires symfony/css-selector ^7.1 -> found symfony/css-selector[v7.1.0, ..., v7.4.0] but the package is fixed to v8.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```

Laravel doesn't support/require v8 of Symfony packages yet, but v2.4.0 of `tijsverkoyen/css-to-inline-styles` (which Laravel requires) does.

You could _technically_ get around it by appending the `-W` flag to the command, but it's easier to just allow it for this one package. v8 doesn't appear to have any breaking changes.

Fixes #123
Related: #122
