### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.3, 8.4]
-        laravel: [12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^6.0",
+        "statamic/cms": "^6.5",
         "spatie/simple-excel": "^3.7",
         "symfony/dom-crawler": "^7.1",
         "pixelfear/composer-dist-plugin": "^0.1.5",

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18",
-        "orchestra/testbench": "^10.0",
-        "phpunit/phpunit": "^11.0",
-        "spatie/laravel-ray": "^1.39"
+        "orchestra/testbench": "^10.0 || ^11.0",
+        "phpunit/phpunit": "^11.0 || ^12.0",
+        "spatie/laravel-ray": "^1.43.6"
     },
     "config": {
         "allow-plugins": {
@@ -43,5 +43,7 @@
             "url": "https://github.com/statamic/importer/releases/download/{$version}/dist.tar.gz",
             "path": "dist"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
This pull request adds Laravel 13 support to the Importer addon. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

This PR also adds PHP 8.5 to the testing matrix.

Depends on:
* [x] https://github.com/statamic/cms/pull/13870
