### PR TITLE
Update Release Workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/dist/**/* linguist-generated=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,59 @@
-name: Release
+name: Create Release
 
 on: # zizmor: ignore[concurrency-limits]
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, without the v prefix (e.g. 1.2.0)'
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
-  release: # zizmor: ignore[anonymous-definition]
-    name: Prepare & Create Release
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # create GitHub release and upload assets
+    environment: Releases
+    permissions: {} # all writes go through the App token; GITHUB_TOKEN needs no scopes
     steps:
-      - name: Checkout code
+      - name: Resolve and validate version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          version="${INPUT_VERSION#v}"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Version must look like 1.2.0 (got: $INPUT_VERSION)"
+            exit 1
+          fi
+
+          if [[ "$BRANCH" =~ ^[0-9]+\.x$ ]] && [ "${version%%.*}" != "${BRANCH%%.*}" ]; then
+            echo "::error::Version $version does not belong on the $BRANCH branch"
+            exit 1
+          fi
+
+          echo "TAG=v$version" >> "$GITHUB_ENV"
+
+      - name: Get release bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true # zizmor: ignore[artipacked] App token is needed to push the tag
+
+      - name: Assert tag does not already exist
+        run: |
+          existing="$(git ls-remote --tags origin "$TAG")"
+          [ -z "$existing" ] || { echo "::error::Tag $TAG already exists on remote. Aborting."; exit 1; }
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -26,34 +62,56 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           tools: composer:v2
 
-      - name: Install Composer Dependencies
+      - name: Use Node.js 20.19.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20.19.0
+          package-manager-cache: false
+
+      - name: Install Composer dependencies
         run: composer install
 
-      - name: Install NPM Dependencies
+      - name: Install NPM dependencies
         run: npm ci
 
-      - name: Compile assets
+      - name: Build release assets
         run: npm run build
 
-      - name: Create zip
-        run: tar -czvf dist.tar.gz dist
+      - name: Create the build commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add --force dist
+          git commit -m "Build assets for $TAG"
+
+      - name: Tag and push the build commit
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
 
       - name: Get Changelog
         id: changelog
-        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1
+        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1.0.2
         with:
-          version: ${{ github.ref }}
+          version: ${{ env.TAG }}
 
       - name: Create release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ steps.changelog.outputs.version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_NOTES: ${{ steps.changelog.outputs.text }}
+          IS_DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
         run: |
-          PRERELEASE=""
-          if [[ "$RELEASE_VERSION" == *-beta* ]]; then PRERELEASE="--prerelease"; fi
-          gh release create "$RELEASE_VERSION" \
-            --title "$RELEASE_VERSION" \
+          latest="$IS_DEFAULT_BRANCH"
+          prerelease=false
+          case "$TAG" in
+            *-*) prerelease=true; latest=false ;;
+          esac
+          gh release create "$TAG" \
+            --title "$TAG" \
             --notes "$RELEASE_NOTES" \
-            $PRERELEASE \
-            ./dist.tar.gz
+            --latest="$latest" \
+            --prerelease="$prerelease"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "statamic/cms": "^6.25",
         "spatie/simple-excel": "^3.7",
         "symfony/dom-crawler": "^7.1",
-        "pixelfear/composer-dist-plugin": "^0.1.5",
         "symfony/css-selector": "^7.1 || ^8.0"
     },
     "require-dev": {
@@ -23,11 +22,6 @@
         "orchestra/testbench": "^10.0 || ^11.0",
         "phpunit/phpunit": "^11.0 || ^12.0",
         "spatie/laravel-ray": "^1.43.6"
-    },
-    "config": {
-        "allow-plugins": {
-            "pixelfear/composer-dist-plugin": true
-        }
     },
     "extra": {
         "statamic": {
@@ -38,10 +32,6 @@
             "providers": [
                 "Statamic\\Importer\\ServiceProvider"
             ]
-        },
-        "download-dist": {
-            "url": "https://github.com/statamic/importer/releases/download/{$version}/dist.tar.gz",
-            "path": "dist"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
This pull request updates the addon's release workflow, replacing `pixelfear/composer-dist-plugin` (which fetched compiled assets at install time) with a CI-driven release that builds the assets into the released tag itself. Consumers get the built `dist` inside the Packagist zip — no post-install fetch.

Related: statamic/cms#14804